### PR TITLE
Fix demo deployment pipeline

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -32,7 +32,7 @@ jobs:
       ## Run lint, test, and build for all affected projects
       - run: npx nx affected --target=lint --parallel=3
       - run: npx nx affected --target=test --parallel=3 --configuration=ci
-      - run: npx nx affected --target=build --parallel=3
+      - run: npx nx run demo:build
 
       ## Configure AWS credentials for deployment
       - uses: aws-actions/configure-aws-credentials@v1

--- a/apps/demo/app/routes/index.tsx
+++ b/apps/demo/app/routes/index.tsx
@@ -1,7 +1,6 @@
 import { RadiusButton, RadiusAutoBox } from '@rangle/radius-react-core-components';
 
 export default function Index() {
-  console.log(RadiusButton)
   return (
     <>
       <RadiusAutoBox
@@ -14,7 +13,7 @@ export default function Index() {
         width="fill-parent"
         effect={[{ type: 'drop-shadow', color: 'var(--color-core-neutral-500)', offset: [0, 0], blur: 20 }]}
       >
-        Deploy to AWS with Github Action
+        Radius Demo App
         {/* <button> Hello world </button> */}
         <RadiusButton variant="primary">Learn more</RadiusButton>
         {/* <RadiusButton>Get Started</RadiusButton> */}


### PR DESCRIPTION
The deployment pipeline failed because the pipeline was using `nx affected` and the last merge to main branch didn't change anything in the demo app, which skipped building for the components and foundation projects. 

This PR run the build script without the affected flag to fix the failure. As part of the future improvement, we should also make sure the deployment pipeline only runs when there are changes in remix demo app. 