### PR TITLE
[WIP] Typography component

### DIFF
--- a/library/core-components/components/typography/__tests__/typography.test.tsx
+++ b/library/core-components/components/typography/__tests__/typography.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-// import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { toHaveNoViolations, axe } from 'jest-axe';
 

--- a/library/core-components/components/typography/__tests__/typography.test.tsx
+++ b/library/core-components/components/typography/__tests__/typography.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+// import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { toHaveNoViolations, axe } from 'jest-axe';
+
+import { Typography } from '..';
+
+expect.extend(toHaveNoViolations);
+
+describe('<Typography />', () => {
+  test('should render', () => {
+    const { getByText } = render(<Typography>Hello World</Typography>);
+    expect(getByText('Hello World')).toBeInTheDocument();
+  });
+
+  test('should render a <p> tag by default', () => {
+    const { container } = render(<Typography>Hello World</Typography>);
+    expect(container.querySelector('p')).toBeInTheDocument();
+  });
+
+  test('should be polymorphic', () => {
+    const { container } = render(<Typography as="h1">Hello World</Typography>);
+    expect(container.querySelector('h1')).toBeInTheDocument();
+  });
+
+  test('should be left aligned by default', () => {
+    const { getByText } = render(<Typography>Hello World</Typography>);
+    expect(getByText('Hello World')).toHaveStyle('text-align: left');
+  });
+
+  test('should have medium body font by default', () => {
+    const { getByText } = render(<Typography>Hello World</Typography>);
+    expect(getByText('Hello World')).toHaveStyle(
+      'font: var(--typography-body-md)'
+    );
+  });
+
+  test('should have primary text color by default', () => {
+    const { getByText } = render(<Typography>Hello World</Typography>);
+    expect(getByText('Hello World')).toHaveStyle(
+      'color: var(--color-text-on-base-primary)'
+    );
+  });
+
+  test('should have no accessibility violations', async () => {
+    const { getByText } = render(<Typography>Hello World</Typography>);
+    expect(await axe(getByText('Hello World'))).toHaveNoViolations();
+  });
+});

--- a/library/core-components/components/typography/index.ts
+++ b/library/core-components/components/typography/index.ts
@@ -1,0 +1,1 @@
+export * from './typography';

--- a/library/core-components/components/typography/typography.stories.tsx
+++ b/library/core-components/components/typography/typography.stories.tsx
@@ -50,7 +50,7 @@ export const Example: ComponentStory<typeof Typography> = () => (
     </Typography>
     <Typography
       font="var(--typography-body-sm)"
-      color="--color-text-on-base-secondary"
+      color="var(--color-text-on-base-secondary)"
       align="right"
     >
       *Footnote

--- a/library/core-components/components/typography/typography.stories.tsx
+++ b/library/core-components/components/typography/typography.stories.tsx
@@ -8,6 +8,8 @@ export default {
   title: `Core Components/Typography`,
   parameters: {
     badges: [BADGE.EXPERIMENTAL],
+    componentSubtitle:
+      'This Polymorphic component provides an interface to apply styles and semantics to text content.',
   },
   argTypes: {
     children: {
@@ -34,12 +36,29 @@ export default {
 
 const Template: ComponentStory<typeof Typography> = (
   args: ComponentProps<typeof Typography>
-) => (
-  <div>
-    <Typography {...args} />
-  </div>
-);
+) => <Typography {...args} />;
 
 export const Default: typeof Template = Template.bind({});
-Default.storyName = 'Typography';
 Default.args = {};
+
+export const Example: ComponentStory<typeof Typography> = () => (
+  <div>
+    <Typography font="var(--typography-heading-xl)">Title</Typography>
+    <Typography color="var(--color-text-on-base-accent)">
+      Some body text. Lorem ipsum dolor sit, amet consectetur adipisicing elit.
+      Fuga, blanditiis.
+    </Typography>
+    <Typography
+      font="var(--typography-body-sm)"
+      color="--color-text-on-base-secondary"
+      align="right"
+    >
+      *Footnote
+    </Typography>
+  </div>
+);
+Example.parameters = {
+  controls: {
+    disable: true,
+  },
+};

--- a/library/core-components/components/typography/typography.stories.tsx
+++ b/library/core-components/components/typography/typography.stories.tsx
@@ -1,0 +1,38 @@
+import React, { ComponentProps } from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
+import { Typography } from './typography';
+
+export default {
+  component: Typography,
+  title: `Core Components/Typography`,
+  parameters: {
+    badges: [BADGE.EXPERIMENTAL],
+  },
+  argTypes: {
+    children: {
+      type: { name: 'string', required: true },
+      defaultValue: 'Hello World!',
+      control: {
+        type: 'text',
+      },
+    },
+    as: {
+      defaultValue: 'div',
+    },
+    align: {
+      defaultValue: 'left',
+    },
+  },
+} as ComponentMeta<typeof Typography>;
+
+const Template: ComponentStory<typeof Typography> = (
+  args: ComponentProps<typeof Typography>
+) => (
+  <div>
+    <Typography {...args} />
+  </div>
+);
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/library/core-components/components/typography/typography.stories.tsx
+++ b/library/core-components/components/typography/typography.stories.tsx
@@ -18,10 +18,16 @@ export default {
       },
     },
     as: {
-      defaultValue: 'div',
+      defaultValue: 'p',
     },
     align: {
       defaultValue: 'left',
+    },
+    color: {
+      defaultValue: 'var(--color-text-on-base-primary)',
+    },
+    font: {
+      defaultValue: 'var(--typography-body-md)',
     },
   },
 } as ComponentMeta<typeof Typography>;
@@ -34,5 +40,6 @@ const Template: ComponentStory<typeof Typography> = (
   </div>
 );
 
-export const Default = Template.bind({});
+export const Default: typeof Template = Template.bind({});
+Default.storyName = 'Typography';
 Default.args = {};

--- a/library/core-components/components/typography/typography.styles.ts
+++ b/library/core-components/components/typography/typography.styles.ts
@@ -1,11 +1,17 @@
 import { css } from '@emotion/css';
 import { TypographyExtendedProps } from './typography';
 
-export type StylesProps = Pick<TypographyExtendedProps, 'align' | 'color'>;
+export type StylesProps = Pick<
+  TypographyExtendedProps,
+  'align' | 'color' | 'font'
+>;
 
-export const getStyles = <T extends StylesProps>({ align, color }: T) => {
+export const getStyles = <T extends StylesProps>({ align, color, font }: T) => {
   return css`
     color: ${color};
     text-align: ${align};
+    font: ${font};
+    margin: 0;
+    padding: 0;
   `;
 };

--- a/library/core-components/components/typography/typography.styles.ts
+++ b/library/core-components/components/typography/typography.styles.ts
@@ -1,0 +1,11 @@
+import { css } from '@emotion/css';
+import { TypographyExtendedProps } from './typography';
+
+export type StylesProps = Pick<TypographyExtendedProps, 'align' | 'color'>;
+
+export const getStyles = <T extends StylesProps>({ align, color }: T) => {
+  return css`
+    color: ${color};
+    text-align: ${align};
+  `;
+};

--- a/library/core-components/components/typography/typography.tsx
+++ b/library/core-components/components/typography/typography.tsx
@@ -27,9 +27,9 @@ export type TypographyExtendedProps = {
   /** Text alignment */
   align?: Alignment;
   /** Text color */
-  color?: string;
+  color?: string; // TODO - add css variable types here
   /** Font (css shorthand property - see https://developer.mozilla.org/en-US/docs/Web/CSS/font) */
-  font?: string;
+  font?: string; // TODO - add css variable types here
   children: React.ReactNode;
 };
 
@@ -38,6 +38,11 @@ export type TypographyProps = PolymorphicComponentPropWithRef<
   TypographyExtendedProps
 >;
 
+/** # Typography Component
+ * A polymorphic component that represents a text element.
+ * Exposes all attributes of the selected tag, plus the specific attributes
+ * declared in the Specific Props type above.
+ */
 export const Typography = forwardRef<TypographyTag, TypographyProps>(
   (
     {

--- a/library/core-components/components/typography/typography.tsx
+++ b/library/core-components/components/typography/typography.tsx
@@ -1,0 +1,61 @@
+import React, { useMemo, forwardRef } from 'react';
+import { PolymorphicComponentPropWithRef } from '../../utils/polymorphic.types';
+import { elementAndProps } from '../../utils/polymorphic.utils';
+
+import { getStyles } from './typography.styles';
+
+export type Alignment = 'center' | 'left' | 'right';
+
+// TODO - fix polymorphic types (type errors due to different expected props for some tags)
+export type TypographyTag =
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  // | 'a'
+  // | 'p'
+  // 'span' |
+  | 'div';
+// | 'article'
+// | 'section'
+// | 'em'
+// | 'strong';
+
+export type TypographyExtendedProps = {
+  align?: Alignment;
+  color?: string;
+  children: React.ReactNode;
+};
+
+export type TypographyProps = PolymorphicComponentPropWithRef<
+  TypographyTag,
+  TypographyExtendedProps
+>;
+
+export const Typography = forwardRef<TypographyTag, TypographyProps>(
+  ({ align, color, children, className, ...rest }: TypographyProps, ref) => {
+    const element = elementAndProps(rest, ref, 'div');
+
+    // TODO - add variants based on tokens?
+    const style = useMemo(
+      () =>
+        getStyles({
+          align,
+          color,
+        }),
+      [align, color]
+    );
+
+    return (
+      <element.Component
+        className={`${style} ${className}`}
+        ref={element.props.ref}
+        {...element.props}
+      >
+        {children}
+      </element.Component>
+    );
+  }
+);

--- a/library/core-components/components/typography/typography.tsx
+++ b/library/core-components/components/typography/typography.tsx
@@ -4,7 +4,7 @@ import { elementAndProps } from '../../utils/polymorphic.utils';
 
 import { getStyles } from './typography.styles';
 
-export type Alignment = 'center' | 'left' | 'right';
+export type Alignment = 'left' | 'center' | 'right';
 
 // TODO - fix polymorphic types (type errors due to different expected props for some tags)
 export type TypographyTag =
@@ -16,16 +16,19 @@ export type TypographyTag =
   | 'h6'
   | 'p'
   | 'div';
+// | 'span'
 // | 'a'
-// 'span' |
 // | 'article'
 // | 'section'
 // | 'em'
 // | 'strong';
 
 export type TypographyExtendedProps = {
+  /** Text alignment */
   align?: Alignment;
+  /** Text color */
   color?: string;
+  /** Font (css shorthand property - see https://developer.mozilla.org/en-US/docs/Web/CSS/font) */
   font?: string;
   children: React.ReactNode;
 };
@@ -49,7 +52,6 @@ export const Typography = forwardRef<TypographyTag, TypographyProps>(
   ) => {
     const element = elementAndProps(rest, ref, 'p');
 
-    // TODO - add variants based on tokens?
     const style = useMemo(
       () =>
         getStyles({

--- a/library/core-components/components/typography/typography.tsx
+++ b/library/core-components/components/typography/typography.tsx
@@ -14,10 +14,10 @@ export type TypographyTag =
   | 'h4'
   | 'h5'
   | 'h6'
-  // | 'a'
-  // | 'p'
-  // 'span' |
+  | 'p'
   | 'div';
+// | 'a'
+// 'span' |
 // | 'article'
 // | 'section'
 // | 'em'
@@ -26,6 +26,7 @@ export type TypographyTag =
 export type TypographyExtendedProps = {
   align?: Alignment;
   color?: string;
+  font?: string;
   children: React.ReactNode;
 };
 
@@ -35,8 +36,18 @@ export type TypographyProps = PolymorphicComponentPropWithRef<
 >;
 
 export const Typography = forwardRef<TypographyTag, TypographyProps>(
-  ({ align, color, children, className, ...rest }: TypographyProps, ref) => {
-    const element = elementAndProps(rest, ref, 'div');
+  (
+    {
+      align = 'left',
+      color = 'var(--color-text-on-base-primary)',
+      font = 'var(--typography-body-md)',
+      children,
+      className,
+      ...rest
+    }: TypographyProps,
+    ref
+  ) => {
+    const element = elementAndProps(rest, ref, 'p');
 
     // TODO - add variants based on tokens?
     const style = useMemo(
@@ -44,8 +55,9 @@ export const Typography = forwardRef<TypographyTag, TypographyProps>(
         getStyles({
           align,
           color,
+          font,
         }),
-      [align, color]
+      [align, color, font]
     );
 
     return (

--- a/shared/fonts/fonts.css
+++ b/shared/fonts/fonts.css
@@ -1,6 +1,6 @@
 /* Riforma regular */
 @font-face {
-  font-family: 'Riforma';
+  font-family: 'Riforma LL';
   src: url('RangleRiformaWeb-Regular.woff2') format('woff2');
   font-weight: 400;
   font-style: normal;
@@ -8,7 +8,7 @@
 
 /* Riforma light */
 @font-face {
-  font-family: 'Riforma';
+  font-family: 'Riforma LL';
   src: url('RangleRiformaWeb-Light.woff2') format('woff2');
   font-weight: 300;
   font-style: normal;
@@ -16,7 +16,7 @@
 
 /* Riforma medium */
 @font-face {
-  font-family: 'Riforma';
+  font-family: 'Riforma LL';
   src: url('RangleRiformaLL-Medium.woff2') format('woff2');
   font-weight: 500;
   font-style: normal;


### PR DESCRIPTION
Story: https://rangle.atlassian.net/browse/R20-143

Created a new polymorphic typography component with props for `font`, `color`, and `align` (text-align).

## To Do
- Fix issue with certain tags in polymorphic application (currently commented out). These tags result in type errors due to different prop expectations:
  - <img width="555" alt="Screenshot 2023-03-01 at 4 35 40 PM" src="https://user-images.githubusercontent.com/23023263/222270152-9d4797d8-4d34-4150-8fed-994e389988be.png">
- Create types for CSS variables instead of just using type `string`