### PR TITLE
Adds a generator template to the importer that produces types for tokens

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -6,14 +6,14 @@
   "scripts": {
     "build": "remix build",
     "dev": "remix dev",
-    "dev:serverless":"sst env remix dev",
+    "dev:serverless": "sst env remix dev",
     "start": "remix-serve build",
     "test": "jest",
     "deploy:serverless": "sst deploy"
   },
   "dependencies": {
+    "@rangle/radius-foundations": "*",
     "@rangle/radius-react-core-components": "^0.1.0",
-    "@rangle/radius-react-core-foundations": "^0.1.0",
     "@remix-run/node": "^1.5.1",
     "@remix-run/react": "^1.5.1",
     "@remix-run/serve": "^1.5.1",

--- a/config/typescript/tsconfig.json
+++ b/config/typescript/tsconfig.json
@@ -17,5 +17,5 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },
-  "exclude": ["**/node_modules", "dist", "build", "docs", "library"]
+  "exclude": ["**/node_modules", "dist", "build", "docs", "app"]
 }

--- a/library/core-components/package.json
+++ b/library/core-components/package.json
@@ -27,6 +27,7 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
+    "@rangle/radius-foundations": "*",
     "@emotion/cache": "^11.10.5",
     "@emotion/css": "^11.10.5",
     "@emotion/react": "^11.10.5",
@@ -40,7 +41,6 @@
     "classnames": "^2.3.1"
   },
   "devDependencies": {
-    "@rangle/radius-react-core-foundations": "^0.1.0",
     "@rollup/plugin-commonjs": "^23.0.2",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^9.0.2",

--- a/library/foundations/README.md
+++ b/library/foundations/README.md
@@ -31,3 +31,11 @@ This script validates the token layers by comparing them with the original token
 This script generates the theme by using the generated token layers file with the package version as a suffix if a RADIUS_LAYERS_SUFFIX environment variable is set. It outputs the theme to the generated directory in the format specified by the second argument (in this case, css).
 
 It is important to note that the tokens:ci and tokens:update scripts use the RADIUS_LAYERS_SUFFIX environment variable to append the package version to the output file name. It is recommended to use these scripts in the specific scenarios described above.
+
+## yarn tokens:types
+
+This script generates type definition files by using the generated token layers file. It outputs them to the generated directory as a typescript file. It will run prettier afterwards to ensure the file obeys
+linting rules.
+
+These type definitions allow developers to use tokens in their component files without resorting to 
+javascript themes in runtime.

--- a/library/foundations/package.json
+++ b/library/foundations/package.json
@@ -1,19 +1,24 @@
 {
-  "name": "@rangle/radius-react-core-foundations",
+  "name": "@rangle/radius-foundations",
   "version": "0.1.0",
   "description": "Foundation scripts and variables for Design Systems",
-  "main": "index.js",
+  "files": [
+    "docs/",
+    "generated/"
+  ],
+  "types": "generated/design-tokens.types.ts",
   "repository": {
     "url": "ssh://git@github.com:rangle/radius-monorepo-react.git"
   },
   "scripts": {
     "test": "jest",
     "tokens:ci": "RADIUS_LAYERS_SUFFIX=-${npm_package_version} yarn tokens:validate",
-    "tokens:update": "export RADIUS_LAYERS_SUFFIX=-${npm_package_version} && yarn tokens:parse && yarn tokens:validate && yarn tokens:generate && yarn tokens:docs",
+    "tokens:update": "export RADIUS_LAYERS_SUFFIX=-${npm_package_version} && yarn tokens:parse && yarn tokens:validate && yarn tokens:generate && yarn tokens:docs && yarn tokens:types",
     "tokens:parse": "cat ./tokens.json | ts-node scripts/to-layers.ts > generated/token-layers${RADIUS_LAYERS_SUFFIX}.json",
     "tokens:validate": "cat ./tokens.json | ts-node scripts/validate-layers.ts generated/token-layers${RADIUS_LAYERS_SUFFIX}.json",
     "tokens:generate": "cat generated/token-layers${RADIUS_LAYERS_SUFFIX}.json | ts-node scripts/generate-theme.ts css > generated/theme.css",
     "tokens:docs": "cat generated/token-layers${RADIUS_LAYERS_SUFFIX}.json | ts-node scripts/generate-theme.ts storybook > generated/04-token-documentation.stories.mdx && prettier --version && prettier --config ../../.prettierrc --parser mdx --write generated/04-token-documentation.stories.mdx",
+    "tokens:types": "cat generated/token-layers${RADIUS_LAYERS_SUFFIX}.json | ts-node scripts/generate-theme.ts types > generated/design-tokens.types.ts && prettier --config ../../.prettierrc --write generated/design-tokens.types.ts",
     "build": "yarn tokens:update"
   },
   "jest": {

--- a/library/foundations/scripts/generate-theme.ts
+++ b/library/foundations/scripts/generate-theme.ts
@@ -8,7 +8,11 @@ import {
   GeneratorMappingFunction,
   createReplaceFunction,
 } from './lib/token-parser';
-import { renderStorybookStory, renderCSSVariables } from './templates';
+import {
+  renderStorybookStory,
+  renderCSSVariables,
+  renderTokenTypes,
+} from './templates';
 
 type RenderFunction = (
   { order, layers }: TokenLayers,
@@ -60,6 +64,8 @@ export const loadGeneratorMappings = (templateName: string) => {
 const templates: RenderTemplateMap = {
   // render css variables
   css: renderCSSVariables,
+  // render token types
+  types: renderTokenTypes,
   // render storybook theme
   storybook: renderStorybookStory,
   // default template for the test runner

--- a/library/foundations/scripts/lib/token-parser.ts
+++ b/library/foundations/scripts/lib/token-parser.ts
@@ -563,7 +563,7 @@ export const processLayers = <T extends TokenStructure>(
         isStatic,
         parameters[PARAM_SECTION_NAME]
       );
-      return { name, variables, parameters, isDynamic: isStatic };
+      return { name, variables, parameters, isStatic };
     })
     .map((layer): TokenLayer => {
       const { variables, parameters, ...rest } = layer;

--- a/library/foundations/scripts/templates/index.ts
+++ b/library/foundations/scripts/templates/index.ts
@@ -1,2 +1,3 @@
 export * from './css-variables.template';
 export * from './storybook.template';
+export * from './token-types.template';

--- a/library/foundations/scripts/templates/token-types.template.ts
+++ b/library/foundations/scripts/templates/token-types.template.ts
@@ -1,0 +1,94 @@
+/*
+   TEMPLATE FOR TYPESCRIPT TOKEN TYPES
+  Generates a TypeScript file with all the tokens in the theme
+*/
+import type { TokenLayers } from '../lib/token-parser';
+
+const EXCLUDE_LAYERS = ['radius--core'];
+
+// convert kebab case to CamelCase. convers a special case when there's two dashes
+const toCamelCase = (str: string) =>
+  str
+    .replace(/--/g, '-')
+    .replace(/-([a-zA-Z])/g, (_, letter) => letter.toUpperCase())
+    .replace(/^([a-zA-Z])/g, (_, letter) => letter.toUpperCase());
+
+// groups an array of dash-separated strings into an object with the first part of the string as the key
+// and the value is an array of all the strings that start with the key
+const groupByPrefix = (index: number, arr: string[]) =>
+  arr.reduce((acc, curr) => {
+    const prefix = curr.split('-')[index];
+    if (!acc[prefix]) {
+      acc[prefix] = [];
+    }
+    return { ...acc, [prefix]: [...acc[prefix], curr] };
+  }, {} as Record<string, string[]>);
+
+type NU<T> = T extends undefined ? never : T;
+const isNotUndefined = <T>(u: T): u is NU<T> => u !== undefined;
+
+export const renderTokenTypes = ({ order, layers }: TokenLayers) => {
+  const layerVariables = order
+    .map((layer) =>
+      layers.find((l) => l.name === layer && !EXCLUDE_LAYERS.includes(l.name))
+    )
+    .filter(isNotUndefined)
+    .map((layer) => {
+      const { name, variables } = layer;
+      return {
+        name: toCamelCase(name),
+        keys: variables.map((variable) => variable.key),
+      };
+    });
+
+  const allKeys = layerVariables.flatMap(({ keys }) => keys);
+  const allKeysByType = groupByPrefix(2, allKeys);
+  const allKeysBySubject = groupByPrefix(3, allKeys);
+
+  const typeNames = Object.keys(allKeysByType);
+  const subjectNames = Object.keys(allKeysBySubject);
+
+  return Buffer.from(`
+  // Layer Types
+    ${layerVariables
+      .map(
+        ({ name, keys }) => `
+    export type ${name}LayerTokens =
+      ${keys.map((key) => `'${key}'`).join(' | ')};
+    `
+      )
+      .join('\n')}
+
+  // All Tokens
+    export type RadiusTokens = ${layerVariables
+      .map(({ name }) => `${name}LayerTokens`)
+      .join(' | ')};
+
+  // Token Types
+
+  export type RadiusTokenTypes = ${typeNames
+    .map((type) => `'${type}'`)
+    .join(' | ')};
+
+  // Tokens By Type (--color, --typography, etc.)
+    ${typeNames
+      .map(
+        (type) => `
+    export type Radius${toCamelCase(
+      type
+    )}Tokens = Extract<RadiusTokens, \`--${type}-\${string}\`>;`
+      )
+      .join('\n')};
+
+  // Tokens By Subject (--color-button, --typography-button, etc.)
+    ${subjectNames
+      .map(
+        (subject) => `
+    export type Radius${toCamelCase(
+      subject
+    )}Tokens<T extends RadiusTokenTypes=RadiusTokenTypes> = 
+      Extract<RadiusTokens, \`--\${T}-${subject}-\${string}\`>;`
+      )
+      .join('\n')};
+  `);
+};


### PR DESCRIPTION
The generator now Produces types representing all Design Token keys.

Added the ability to filter these types by their _type_ and _subject_.
Ex: in `—color-button-primary-active` the type of the token is `color` and the subject is `button` (this is done by their positions). Currently the script only organizes positions 1 and 2, but it can be extended easily to include more.  

components can have props of a specific type of token to accept only ‘button color tokens’ for example.

The resulting generated type file was added as the default type export of the example library `@rangle/radius-foundations` — this name should be replaced by the name of the target design system’s foundations package. Documentation for this process is not yet added.