### PR TITLE
fix CSS encapsulation issue

### DIFF
--- a/library/core-components/components/auto-box/auto-box.tsx
+++ b/library/core-components/components/auto-box/auto-box.tsx
@@ -1,9 +1,11 @@
 import React, { useMemo, forwardRef } from 'react';
+import { cx } from '@emotion/css';
+
 import { PolymorphicComponentPropWithRef } from '../../utils/polymorphic.types';
+import { elementAndProps } from '../../utils/polymorphic.utils';
 
 import { AutoLayoutProps } from './auto-box.types';
 import { getStyles } from './auto-box.styles';
-import { elementAndProps } from '../../utils/polymorphic.utils';
 
 type RadiusButtonTag = React.ElementType;
 export type RadiusAutoBoxProps = PolymorphicComponentPropWithRef<
@@ -24,7 +26,7 @@ export const RadiusAutoBox = forwardRef<RadiusButtonTag, RadiusAutoBoxProps>(
     const styles = useMemo(() => getStyles(rest), [rest]);
     return (
       <element.Component
-        className={`${styles} ${className || ''}`}
+        className={cx(styles, className)}
         {...element.props}
         ref={ref}
       >

--- a/library/core-components/components/button/button.tsx
+++ b/library/core-components/components/button/button.tsx
@@ -1,4 +1,6 @@
 import React, { useMemo, forwardRef } from 'react';
+import { cx } from '@emotion/css';
+
 import { PolymorphicComponentPropWithRef } from '../../utils/polymorphic.types';
 import { elementAndProps } from '../../utils/polymorphic.utils';
 
@@ -88,7 +90,7 @@ export const RadiusButton = forwardRef<RadiusButtonTag, RadiusButtonProps>(
 
       return (
         <element.Component
-          className={`${style} ${className}`}
+          className={cx(style, className)}
           ref={element.props.ref}
           {...element.props}
         >
@@ -104,7 +106,7 @@ export const RadiusButton = forwardRef<RadiusButtonTag, RadiusButtonProps>(
       //   const ok = props.href;  // works fine
       return (
         <element.Component
-          className={`${style} ${className}`}
+          className={cx(style, className)}
           ref={element.props.ref}
           {...element.props}
         >

--- a/library/core-components/components/hero/hero.tsx
+++ b/library/core-components/components/hero/hero.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { cx } from '@emotion/css';
+
 import { RadiusAutoBox } from '../../components/auto-box/auto-box';
 import { RadiusButton } from '../../components/button/button';
 import { Typography } from '../../components/typography/typography';
@@ -9,17 +11,19 @@ export type HeroProps = {
   eyebrow: string;
   buttonLabel: string;
   imageSrc: string;
-};
+} & React.HTMLAttributes<HTMLDivElement>;
 
 export const RadiusHero = ({
   title,
   eyebrow,
   buttonLabel,
   imageSrc,
+  className,
+  ...rest
 }: HeroProps) => {
   const heroStyle = getStyles();
   return (
-    <RadiusAutoBox className={heroStyle}>
+    <RadiusAutoBox className={cx(heroStyle, className)} {...rest}>
       <RadiusAutoBox
         width="fill-parent"
         space={24}

--- a/library/core-components/components/typography/typography.tsx
+++ b/library/core-components/components/typography/typography.tsx
@@ -1,4 +1,6 @@
 import React, { useMemo, forwardRef } from 'react';
+import { cx } from '@emotion/css';
+
 import { PolymorphicComponentPropWithRef } from '../../utils/polymorphic.types';
 import { elementAndProps } from '../../utils/polymorphic.utils';
 
@@ -69,7 +71,7 @@ export const Typography = forwardRef<TypographyTag, TypographyProps>(
 
     return (
       <element.Component
-        className={`${style} ${className}`}
+        className={cx(style, className)}
         ref={element.props.ref}
         {...element.props}
       >


### PR DESCRIPTION
https://rangle.atlassian.net/browse/R20-206

Replaced the existing compositional className implementation with the `@emotion/css` `cx` function. This function ensures the order of emotion-generated classes is the same as they are provided to the function. This solves the problem of inconsistency when attempting to override parent styles (eg. overriding Autobox default styles).

See relevant docs here: https://emotion.sh/docs/@emotion/css#cx