### PR TITLE
Token type implementation & AutoBox refactor

### DIFF
--- a/library/core-components/components/auto-box/__tests__/auto-box.styles.test.tsx
+++ b/library/core-components/components/auto-box/__tests__/auto-box.styles.test.tsx
@@ -1,14 +1,5 @@
 // import userEvent from '@testing-library/user-event';
-import {
-  getSize,
-  getCssValue,
-  getPadding,
-  getColor,
-  getStrokeWidth,
-  getCornerRadius,
-  setPosition,
-  getEffects,
-} from '../auto-box.styles';
+import { getSize, getCssValue, setPosition } from '../auto-box.styles';
 
 describe('AutoBox Styles', () => {
   test('getSize', () => {
@@ -29,71 +20,6 @@ describe('AutoBox Styles', () => {
     expect(getCssValue()).toBe('0px');
   });
 
-  test('getPadding', () => {
-    expect(getPadding(5)).toBe('5px');
-    expect(getPadding('5px')).toBe('5px');
-    expect(getPadding('5%')).toBe('5%');
-    expect(getPadding('var(--the-width)')).toBe('var(--the-width)');
-
-    expect(getPadding({ vertical: 5, horizontal: '5px' })).toBe('5px 5px');
-    expect(getPadding({ vertical: '5%', horizontal: 'var(--the-width)' })).toBe(
-      '5% var(--the-width)'
-    );
-    expect(
-      getPadding({
-        top: 5,
-        right: '5px',
-        bottom: '5%',
-        left: 'var(--the-width)',
-      })
-    ).toBe('5px 5px 5% var(--the-width)');
-    expect(getPadding()).toBe('0px');
-  });
-
-  test('getColor', () => {
-    expect(getColor('#f00')).toBe('#f00');
-    expect(getColor('#ff0000')).toBe('#ff0000');
-    expect(getColor({ r: 255, g: 255, b: 255, a: 0.5 })).toBe(
-      'rgba(255,255,255,0.5)'
-    );
-    expect(getColor({ r: 255, g: 255, b: 255, a: 50 })).toBe(
-      'rgba(255,255,255,0.5)'
-    );
-    expect(getColor('var(--the-color)')).toBe('var(--the-color)');
-    expect(getColor()).toBe('transparent');
-  });
-
-  test('getStrokeWidth', () => {
-    expect(getStrokeWidth(5)).toBe('border-width: 5px;');
-    expect(getStrokeWidth('5px')).toBe('border-width: 5px;');
-    expect(getStrokeWidth('5%')).toBe('border-width: 5%;');
-    expect(
-      getStrokeWidth({
-        top: 5,
-        right: '5px',
-        bottom: '5%',
-        left: 'var(--var-width)',
-      })
-    ).toBe('border-width: 5px 5px 5% var(--var-width);');
-  });
-
-  test('getCornerRadius', () => {
-    expect(getCornerRadius(5)).toBe('border-radius: 5px;');
-    expect(getCornerRadius('5px')).toBe('border-radius: 5px;');
-    expect(getCornerRadius('5%')).toBe('border-radius: 5%;');
-    expect(getCornerRadius('var(--var-width)')).toBe(
-      'border-radius: var(--var-width);'
-    );
-    expect(
-      getCornerRadius({
-        topLeft: 5,
-        topRight: '5px',
-        bottomRight: '5%',
-        bottomLeft: 'var(--var-width)',
-      })
-    ).toBe('border-radius: 5px 5px 5% var(--var-width);');
-  });
-
   test('setPosition', () => {
     expect(setPosition(5, 'var(--var-width)')).toBe(
       'left: 5px;top: var(--var-width);'
@@ -106,51 +32,5 @@ describe('AutoBox Styles', () => {
     expect(setPosition('5px', '5%', 'right', 'bottom')).toBe(
       'right: 5px;bottom: 5%;'
     );
-  });
-
-  test('getEffects', () => {
-    expect(
-      getEffects({
-        type: 'drop-shadow',
-        offset: [1, 2],
-        color: '#300',
-        blur: 4,
-      })
-    ).toBe(' box-shadow: 1px 2px 4px #300;');
-    expect(
-      getEffects({
-        type: 'inner-shadow',
-        offset: [1, 2],
-        color: '#300',
-        blur: 4,
-      })
-    ).toBe(' box-shadow: inset 1px 2px 4px #300;');
-    expect(
-      getEffects({
-        type: 'layer-blur',
-        blur: 1,
-      })
-    ).toBe(' filter: blur(1px);');
-    expect(
-      getEffects({
-        type: 'background-blur',
-        blur: 1,
-      })
-    ).toBe(' backdrop-filter: blur(1px);');
-
-    expect(
-      getEffects([
-        {
-          type: 'drop-shadow',
-          offset: [1, 2],
-          color: '#300',
-          blur: 4,
-        },
-        {
-          type: 'layer-blur',
-          blur: 1,
-        },
-      ])
-    ).toBe(' box-shadow: 1px 2px 4px #300; filter: blur(1px);');
   });
 });

--- a/library/core-components/components/auto-box/auto-box-alignment.stories.tsx
+++ b/library/core-components/components/auto-box/auto-box-alignment.stories.tsx
@@ -42,22 +42,22 @@ const ThreeBoxesTemplateAlignmentHor = (args: {
       alignment={args.parent.alignment}
       width="fill-parent"
       height={args.parent.direction === 'horizontal' ? 'fill-parent' : '100px'}
-      padding={10}
+      padding="--spacing-core-space-3x"
     >
       <RadiusAutoBox
         width={args.children.width}
         height={20}
-        fill="var(--color-button-primary-surface-hover)"
+        fill="--color-button-primary-surface-hover"
       />
       <RadiusAutoBox
         width={args.children.width}
         height={40}
-        fill="var(--color-button-primary-surface-hover)"
+        fill="--color-button-primary-surface-hover"
       />
       <RadiusAutoBox
         width={args.children.width}
         height={60}
-        fill="var(--color-button-primary-surface-hover)"
+        fill="--color-button-primary-surface-hover"
       />
     </RadiusAutoBox>
   </RadiusAutoBox>
@@ -126,22 +126,22 @@ const ThreeBoxesTemplateAlignmentVert = (args: {
       alignment={args.parent.alignment}
       width="fill-parent"
       height={args.parent.direction === 'horizontal' ? 'fill-parent' : '100px'}
-      padding={10}
+      padding="--spacing-core-space-3x"
     >
       <RadiusAutoBox
         width="25%"
         height={10}
-        fill="var(--color-button-primary-surface-hover)"
+        fill="--color-button-primary-surface-hover"
       />
       <RadiusAutoBox
         width="50%"
         height={10}
-        fill="var(--color-button-primary-surface-hover)"
+        fill="--color-button-primary-surface-hover"
       />
       <RadiusAutoBox
         width="75%"
         height={10}
-        fill="var(--color-button-primary-surface-hover)"
+        fill="--color-button-primary-surface-hover"
       />
     </RadiusAutoBox>
   </RadiusAutoBox>

--- a/library/core-components/components/auto-box/auto-box-layout.stories.tsx
+++ b/library/core-components/components/auto-box/auto-box-layout.stories.tsx
@@ -42,22 +42,22 @@ const ThreeBoxesTemplate = (args: {
       alignment={args.parent.alignment}
       width="fill-parent"
       height={args.parent.direction === 'horizontal' ? 'fill-parent' : '100px'}
-      padding={10}
+      padding="--spacing-core-space-3x"
     >
       <RadiusAutoBox
         width={args.children.width}
         height={args.children.height}
-        fill="var(--color-button-primary-surface-hover)"
+        fill="--color-button-primary-surface-hover"
       />
       <RadiusAutoBox
         width={args.children.width}
         height={args.children.height}
-        fill="var(--color-button-primary-surface-hover)"
+        fill="--color-button-primary-surface-hover"
       />
       <RadiusAutoBox
         width={args.children.width}
         height={args.children.height}
-        fill="var(--color-button-primary-surface-hover)"
+        fill="--color-button-primary-surface-hover"
       />
     </RadiusAutoBox>
   </RadiusAutoBox>
@@ -88,7 +88,7 @@ export const FixedWidthHorizontalDefinedSpacing = ThreeBoxesTemplate.bind({});
 FixedWidthHorizontalDefinedSpacing.args = {
   parent: {
     direction: 'horizontal',
-    space: '10px',
+    space: '--spacing-core-space-3x',
     alignment: 'top',
   },
   children: {
@@ -106,7 +106,7 @@ export const FillWidthHorizontal = ThreeBoxesTemplate.bind({});
 FillWidthHorizontal.args = {
   parent: {
     direction: 'horizontal',
-    space: 5,
+    space: '--spacing-core-space-base',
     alignment: 'top',
   },
   children: {
@@ -142,7 +142,7 @@ export const FixedHeightVerticalDefinedSpacing = ThreeBoxesTemplate.bind({});
 FixedHeightVerticalDefinedSpacing.args = {
   parent: {
     direction: 'vertical',
-    space: '20px',
+    space: '--spacing-core-space-5x',
     alignment: 'left',
   },
   children: {
@@ -160,7 +160,7 @@ export const FillHeightVertical = ThreeBoxesTemplate.bind({});
 FillHeightVertical.args = {
   parent: {
     direction: 'vertical',
-    space: '5px',
+    space: '--spacing-core-space-base',
     alignment: 'left',
   },
   children: {

--- a/library/core-components/components/auto-box/auto-box.stories.tsx
+++ b/library/core-components/components/auto-box/auto-box.stories.tsx
@@ -186,7 +186,7 @@ AutoBox.args = {
   stroke: '--color-text-secondary-action-default',
   strokeWidth: { top: 1, right: 1, bottom: 1, left: 1 },
   strokeAlign: undefined,
-  cornerRadius: { topLeft: 0, topRight: 0, bottomRight: 0, bottomLeft: 0 },
+  cornerRadius: '--borderRadius-core-radius-none',
   opacity: undefined,
   clippedContent: false,
   isParent: false,
@@ -360,19 +360,19 @@ const BorderRadiusTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
     <RadiusAutoBox
       width={50}
       height={50}
-      cornerRadius={5}
+      cornerRadius="--borderRadius-core-radius-xsm"
       stroke="--color-button-primary-surface-hover"
     />
     <RadiusAutoBox
       width={50}
       height={50}
-      cornerRadius="20px"
+      cornerRadius="--borderRadius-core-radius-md"
       stroke="--color-button-primary-surface-hover"
     />
     <RadiusAutoBox
       width={50}
       height={50}
-      cornerRadius="100%"
+      cornerRadius="--borderRadius-core-radius-max"
       stroke="--color-button-primary-surface-hover"
     />
   </RadiusAutoBox>

--- a/library/core-components/components/auto-box/auto-box.stories.tsx
+++ b/library/core-components/components/auto-box/auto-box.stories.tsx
@@ -158,22 +158,22 @@ const Template: ComponentStory<typeof RadiusAutoBox> = (
     <RadiusAutoBox
       width={100}
       height="fill-parent"
-      fill="var(--color-button-primary-surface-hover)"
+      fill="--color-button-primary-surface-hover"
     />
     <RadiusAutoBox
       width={100}
       height="fill-parent"
-      fill="var(--color-button-primary-surface-hover)"
+      fill="--color-button-primary-surface-hover"
     />
     <RadiusAutoBox
       width={100}
       height="fill-parent"
-      fill="var(--color-button-primary-surface-hover)"
+      fill="--color-button-primary-surface-hover"
     />
   </RadiusAutoBox>
 );
 
-export const AutoBox = Template.bind({});
+export const AutoBox: typeof Template = Template.bind({});
 AutoBox.args = {
   as: 'div',
   direction: 'horizontal',
@@ -182,8 +182,8 @@ AutoBox.args = {
   height: '200px',
   space: 'auto',
   padding: { top: 20, right: 20, bottom: 20, left: 20 },
-  fill: 'var(--color-button-primary-surface-default))',
-  stroke: 'var(--color-text-secondary-action-default)',
+  fill: '--color-button-primary-surface-default',
+  stroke: '--color-text-secondary-action-default',
   strokeWidth: { top: 1, right: 1, bottom: 1, left: 1 },
   strokeAlign: undefined,
   cornerRadius: { topLeft: 0, topRight: 0, bottomRight: 0, bottomLeft: 0 },
@@ -206,20 +206,20 @@ const paddingTemplate: ComponentStory<typeof RadiusAutoBox> = (
       width={100}
       height={25}
       padding={{ left: '20px', top: '50px' }}
-      fill="var(--color-button-primary-surface-hover)"
+      fill="--color-button-primary-surface-hover"
     />
 
     <RadiusAutoBox
       width={100}
       height={25}
       padding={{ vertical: 30 }}
-      fill="var(--color-button-primary-surface-hover)"
+      fill="--color-button-primary-surface-hover"
     />
     <RadiusAutoBox
       width={100}
       height={25}
       padding={50}
-      fill="var(--color-button-primary-surface-hover)"
+      fill="--color-button-primary-surface-hover"
     />
   </RadiusAutoBox>
 );
@@ -241,35 +241,35 @@ const OpacityTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
       width={100}
       height={25}
       opacity={0.05}
-      stroke="var(--color-button-primary-surface-default)"
-      fill="var(--color-button-primary-surface-default)"
+      stroke="--color-button-primary-surface-default"
+      fill="--color-button-primary-surface-default"
     />
     <RadiusAutoBox
       width={100}
       height={25}
       opacity={0.25}
-      stroke="var(--color-button-primary-surface-default)"
-      fill="var(--color-button-primary-surface-default)"
+      stroke="--color-button-primary-surface-default"
+      fill="--color-button-primary-surface-default"
     />
     <RadiusAutoBox
       width={100}
       height={25}
       opacity={0.5}
-      stroke="var(--color-button-primary-surface-default)"
-      fill="var(--color-button-primary-surface-default)"
+      stroke="--color-button-primary-surface-default"
+      fill="--color-button-primary-surface-default"
     />
     <RadiusAutoBox
       width={100}
       height={25}
       opacity={0.75}
-      stroke="var(--color-button-primary-surface-default)"
-      fill="var(--color-button-primary-surface-default)"
+      stroke="--color-button-primary-surface-default"
+      fill="--color-button-primary-surface-default"
     />
     <RadiusAutoBox
       width={100}
       height={25}
-      stroke="var(--color-button-primary-surface-default)"
-      fill="var(--color-button-primary-surface-default)"
+      stroke="--color-button-primary-surface-default"
+      fill="--color-button-primary-surface-default"
     />
   </RadiusAutoBox>
 );
@@ -324,20 +324,20 @@ const BorderTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
     <RadiusAutoBox
       width={50}
       height={50}
-      stroke="var(--color-button-primary-surface-hover)"
+      stroke="--color-button-primary-surface-hover"
       strokeWidth={5}
     />
     <RadiusAutoBox
       width={50}
       height={50}
-      stroke="var(--color-button-primary-surface-hover)"
+      stroke="--color-button-primary-surface-hover"
       strokeAlign={`outside`}
       strokeWidth={`10px`}
     />
     <RadiusAutoBox
       width={50}
       height={50}
-      stroke="var(--color-button-primary-surface-hover)"
+      stroke="--color-button-primary-surface-hover"
       strokeAlign={'inside'}
       strokeWidth={{ left: 5, top: '20px', right: 0, bottom: 1 }}
     />
@@ -361,19 +361,19 @@ const BorderRadiusTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
       width={50}
       height={50}
       cornerRadius={5}
-      stroke="var(--color-button-primary-surface-hover)"
+      stroke="--color-button-primary-surface-hover"
     />
     <RadiusAutoBox
       width={50}
       height={50}
       cornerRadius="20px"
-      stroke="var(--color-button-primary-surface-hover)"
+      stroke="--color-button-primary-surface-hover"
     />
     <RadiusAutoBox
       width={50}
       height={50}
       cornerRadius="100%"
-      stroke="var(--color-button-primary-surface-hover)"
+      stroke="--color-button-primary-surface-hover"
     />
   </RadiusAutoBox>
 );
@@ -389,13 +389,13 @@ const AbsoluteTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
     direction={'vertical'}
     width={'fill-parent'}
     strokeAlign={'inside'}
-    stroke="var(--color-button-primary-surface-default)"
+    stroke="--color-button-primary-surface-default"
     padding={20}
     isParent={true}
     height={200}
   >
     <RadiusAutoBox
-      fill="var(--color-button-primary-surface-default)"
+      fill="--color-button-primary-surface-default"
       style={{ color: 'var(--color-button-primary-label-default)' }}
       padding={10}
       absolutePosition={true}
@@ -406,7 +406,7 @@ const AbsoluteTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
     </RadiusAutoBox>
     <RadiusAutoBox
       padding={10}
-      fill="var(--color-button-primary-surface-default)"
+      fill="--color-button-primary-surface-default"
       style={{ color: 'var(--color-button-primary-label-default)' }}
       horizontalConstraint="right"
       verticalConstraint="bottom"
@@ -435,28 +435,28 @@ const AsElementsTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
     <RadiusAutoBox
       as="h1"
       padding={20}
-      fill="var(--color-button-primary-surface-default)"
+      fill="--color-button-primary-surface-default"
     >
       As h1
     </RadiusAutoBox>
     <RadiusAutoBox
       as="main"
       padding={20}
-      fill="var(--color-button-primary-surface-default)"
+      fill="--color-button-primary-surface-default"
     >
       As main
     </RadiusAutoBox>
     <RadiusAutoBox
       as="ul"
       padding={20}
-      fill="var(--color-button-primary-surface-default)"
+      fill="--color-button-primary-surface-default"
     >
       As ul
     </RadiusAutoBox>
     <RadiusAutoBox
       as="p"
       padding={20}
-      fill="var(--color-button-primary-surface-default)"
+      fill="--color-button-primary-surface-default"
     >
       As paragraph
     </RadiusAutoBox>
@@ -484,7 +484,7 @@ const EffectsTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
         offset: [0, 0],
         blur: 5,
       }}
-      fill="var(--color-button-primary-surface-default)"
+      fill="--color-button-primary-surface-default"
     >
       drop-shadow
     </RadiusAutoBox>
@@ -496,14 +496,14 @@ const EffectsTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
         offset: [0, 0],
         blur: 5,
       }}
-      fill="var(--color-button-primary-surface-default)"
+      fill="--color-button-primary-surface-default"
     >
       inner-shadow
     </RadiusAutoBox>
     <RadiusAutoBox
       padding={20}
       effect={{ type: 'layer-blur', blur: 1 }}
-      fill="var(--color-button-primary-surface-default)"
+      fill="--color-button-primary-surface-default"
     >
       layer-blur
     </RadiusAutoBox>
@@ -530,7 +530,7 @@ const EffectsTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
         { type: 'layer-blur', blur: 1 },
         { type: 'drop-shadow', color: '#000', offset: [0, 0], blur: 20 },
       ]}
-      fill="var(--color-button-primary-surface-default)"
+      fill="--color-button-primary-surface-default"
     >
       layer-blur and drop-shadow
     </RadiusAutoBox>

--- a/library/core-components/components/auto-box/auto-box.stories.tsx
+++ b/library/core-components/components/auto-box/auto-box.stories.tsx
@@ -184,7 +184,7 @@ AutoBox.args = {
   padding: { top: 20, right: 20, bottom: 20, left: 20 },
   fill: '--color-button-primary-surface-default',
   stroke: '--color-text-secondary-action-default',
-  strokeWidth: { top: 1, right: 1, bottom: 1, left: 1 },
+  strokeWidth: '--borderWidth-core-border-width-sm',
   strokeAlign: undefined,
   cornerRadius: '--borderRadius-core-radius-none',
   opacity: undefined,
@@ -325,21 +325,21 @@ const BorderTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
       width={50}
       height={50}
       stroke="--color-button-primary-surface-hover"
-      strokeWidth={5}
+      strokeWidth="--borderWidth-core-border-width-sm"
     />
     <RadiusAutoBox
       width={50}
       height={50}
       stroke="--color-button-primary-surface-hover"
       strokeAlign={`outside`}
-      strokeWidth={`10px`}
+      strokeWidth="--borderWidth-core-border-width-md: 2px;"
     />
     <RadiusAutoBox
       width={50}
       height={50}
       stroke="--color-button-primary-surface-hover"
       strokeAlign={'inside'}
-      strokeWidth={{ left: 5, top: '20px', right: 0, bottom: 1 }}
+      strokeWidth={{ css: '20px 0 1px 5px' }}
     />
   </RadiusAutoBox>
 );

--- a/library/core-components/components/auto-box/auto-box.stories.tsx
+++ b/library/core-components/components/auto-box/auto-box.stories.tsx
@@ -533,7 +533,7 @@ Effects.parameters = {
 const LayoutsTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
   <RadiusAutoBox
     width="fill-parent"
-    space={20}
+    space="--spacing-core-space-5x"
     alignment="center"
     isParent={true}
     style={{ color: 'var(--color-button-primary-surface-default)' }}

--- a/library/core-components/components/auto-box/auto-box.stories.tsx
+++ b/library/core-components/components/auto-box/auto-box.stories.tsx
@@ -240,28 +240,28 @@ const OpacityTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
     <RadiusAutoBox
       width={100}
       height={25}
-      opacity={0.05}
+      opacity="--opacity-core-opacity-lighter"
       stroke="--color-button-primary-surface-default"
       fill="--color-button-primary-surface-default"
     />
     <RadiusAutoBox
       width={100}
       height={25}
-      opacity={0.25}
+      opacity="--opacity-core-opacity-light"
       stroke="--color-button-primary-surface-default"
       fill="--color-button-primary-surface-default"
     />
     <RadiusAutoBox
       width={100}
       height={25}
-      opacity={0.5}
+      opacity="--opacity-core-opacity-dark"
       stroke="--color-button-primary-surface-default"
       fill="--color-button-primary-surface-default"
     />
     <RadiusAutoBox
       width={100}
       height={25}
-      opacity={0.75}
+      opacity="--opacity-core-opacity-darker"
       stroke="--color-button-primary-surface-default"
       fill="--color-button-primary-surface-default"
     />

--- a/library/core-components/components/auto-box/auto-box.stories.tsx
+++ b/library/core-components/components/auto-box/auto-box.stories.tsx
@@ -478,31 +478,21 @@ const EffectsTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
   >
     <RadiusAutoBox
       padding={20}
-      effect={{
-        type: 'drop-shadow',
-        color: 'var(--color-button-primary-surface-default)',
-        offset: [0, 0],
-        blur: 5,
-      }}
+      dropShadow="--boxShadow-core-elevation-100"
       fill="--color-button-primary-surface-default"
     >
       drop-shadow
     </RadiusAutoBox>
     <RadiusAutoBox
       padding={20}
-      effect={{
-        type: 'inner-shadow',
-        color: 'var(--color-button-primary-surface-default)',
-        offset: [0, 0],
-        blur: 5,
-      }}
+      innerShadow="--boxShadow-core-elevation-100"
       fill="--color-button-primary-surface-default"
     >
       inner-shadow
     </RadiusAutoBox>
     <RadiusAutoBox
       padding={20}
-      effect={{ type: 'layer-blur', blur: 1 }}
+      layerBlur={1}
       fill="--color-button-primary-surface-default"
     >
       layer-blur
@@ -518,18 +508,15 @@ const EffectsTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
       <RadiusAutoBox
         style={{ fontWeight: 'bold' }}
         padding={20}
-        effect={{ type: 'background-blur', blur: 3 }}
+        backgroundBlur={3}
       >
         background-blur
       </RadiusAutoBox>
     </RadiusAutoBox>
-
     <RadiusAutoBox
       padding={20}
-      effect={[
-        { type: 'layer-blur', blur: 1 },
-        { type: 'drop-shadow', color: '#000', offset: [0, 0], blur: 20 },
-      ]}
+      layerBlur={1}
+      dropShadow="--boxShadow-core-elevation-100"
       fill="--color-button-primary-surface-default"
     >
       layer-blur and drop-shadow

--- a/library/core-components/components/auto-box/auto-box.stories.tsx
+++ b/library/core-components/components/auto-box/auto-box.stories.tsx
@@ -181,7 +181,7 @@ AutoBox.args = {
   width: 'fill-parent',
   height: '200px',
   space: 'auto',
-  padding: { top: 20, right: 20, bottom: 20, left: 20 },
+  padding: '--spacing-core-space-5x',
   fill: '--color-button-primary-surface-default',
   stroke: '--color-text-secondary-action-default',
   strokeWidth: '--borderWidth-core-border-width-sm',
@@ -205,20 +205,20 @@ const paddingTemplate: ComponentStory<typeof RadiusAutoBox> = (
     <RadiusAutoBox
       width={100}
       height={25}
-      padding={{ left: '20px', top: '50px' }}
+      padding={{ css: '50px 0 0 20px' }}
       fill="--color-button-primary-surface-hover"
     />
 
     <RadiusAutoBox
       width={100}
       height={25}
-      padding={{ vertical: 30 }}
+      padding={{ css: '30px 0' }}
       fill="--color-button-primary-surface-hover"
     />
     <RadiusAutoBox
       width={100}
       height={25}
-      padding={50}
+      padding="--spacing-core-space-12x"
       fill="--color-button-primary-surface-hover"
     />
   </RadiusAutoBox>
@@ -235,7 +235,7 @@ const OpacityTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
     direction="horizontal"
     alignment="top"
     width="fill-parent"
-    padding={10}
+    padding="--spacing-core-space-3x"
   >
     <RadiusAutoBox
       width={100}
@@ -285,25 +285,21 @@ const BackgroundColorTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
     direction="horizontal"
     alignment="top"
     width="fill-parent"
-    padding={10}
+    padding="--spacing-core-space-3x"
   >
-    <RadiusAutoBox width={100} height={25} fill={{ r: 0, g: 0, b: 0, a: 1 }} />
+    <RadiusAutoBox width={100} height={25} fill="--color-background-inverse" />
+    <RadiusAutoBox width={100} height={25} fill="--color-background-accent" />
+    <RadiusAutoBox width={100} height={25} fill={{ css: 'red' }} />
+    <RadiusAutoBox width={100} height={25} fill={{ css: '#0000ff' }} />
     <RadiusAutoBox
       width={100}
       height={25}
-      fill={{ r: 255, g: 0, b: 0, a: 1 }}
-    />
-    <RadiusAutoBox width={100} height={25} fill={'#0f0'} />
-    <RadiusAutoBox width={100} height={25} fill={'#0000ff'} />
-    <RadiusAutoBox
-      width={100}
-      height={25}
-      fill={{ r: 255, g: 150, b: 150, a: 20 }}
+      fill={{ css: 'rgba(255, 150, 150, 20)' }}
     />
     <RadiusAutoBox
       width={100}
       height={25}
-      fill={{ r: 150, g: 255, b: 150, a: 0.2 }}
+      fill={{ css: 'rgba(150, 255, 150, 0.2)' }}
     />
   </RadiusAutoBox>
 );
@@ -319,7 +315,7 @@ const BorderTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
     direction="horizontal"
     alignment="top"
     width="fill-parent"
-    padding={10}
+    padding="--spacing-core-space-3x"
   >
     <RadiusAutoBox
       width={50}
@@ -355,7 +351,7 @@ const BorderRadiusTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
     direction={'horizontal'}
     alignment={'top'}
     width={'fill-parent'}
-    padding={10}
+    padding="--spacing-core-space-3x"
   >
     <RadiusAutoBox
       width={50}
@@ -390,14 +386,14 @@ const AbsoluteTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
     width={'fill-parent'}
     strokeAlign={'inside'}
     stroke="--color-button-primary-surface-default"
-    padding={20}
+    padding="--spacing-core-space-5x"
     isParent={true}
     height={200}
   >
     <RadiusAutoBox
       fill="--color-button-primary-surface-default"
       style={{ color: 'var(--color-button-primary-label-default)' }}
-      padding={10}
+      padding="--spacing-core-space-3x"
       absolutePosition={true}
       x="0%"
       y="0%"
@@ -405,7 +401,7 @@ const AbsoluteTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
       Top Left
     </RadiusAutoBox>
     <RadiusAutoBox
-      padding={10}
+      padding="--spacing-core-space-3x"
       fill="--color-button-primary-surface-default"
       style={{ color: 'var(--color-button-primary-label-default)' }}
       horizontalConstraint="right"
@@ -429,33 +425,33 @@ const AsElementsTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
   <RadiusAutoBox
     direction="horizontal"
     width="fill-parent"
-    padding={10}
+    padding="--spacing-core-space-3x"
     style={{ color: 'var(--color-button-primary-label-default)' }}
   >
     <RadiusAutoBox
       as="h1"
-      padding={20}
+      padding="--spacing-core-space-5x"
       fill="--color-button-primary-surface-default"
     >
       As h1
     </RadiusAutoBox>
     <RadiusAutoBox
       as="main"
-      padding={20}
+      padding="--spacing-core-space-5x"
       fill="--color-button-primary-surface-default"
     >
       As main
     </RadiusAutoBox>
     <RadiusAutoBox
       as="ul"
-      padding={20}
+      padding="--spacing-core-space-5x"
       fill="--color-button-primary-surface-default"
     >
       As ul
     </RadiusAutoBox>
     <RadiusAutoBox
       as="p"
-      padding={20}
+      padding="--spacing-core-space-5x"
       fill="--color-button-primary-surface-default"
     >
       As paragraph
@@ -473,25 +469,25 @@ const EffectsTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
   <RadiusAutoBox
     direction="horizontal"
     width="fill-parent"
-    padding={10}
+    padding="--spacing-core-space-3x"
     style={{ color: 'var(--color-button-primary-label-default)' }}
   >
     <RadiusAutoBox
-      padding={20}
+      padding="--spacing-core-space-5x"
       dropShadow="--boxShadow-core-elevation-100"
       fill="--color-button-primary-surface-default"
     >
       drop-shadow
     </RadiusAutoBox>
     <RadiusAutoBox
-      padding={20}
+      padding="--spacing-core-space-5x"
       innerShadow="--boxShadow-core-elevation-100"
       fill="--color-button-primary-surface-default"
     >
       inner-shadow
     </RadiusAutoBox>
     <RadiusAutoBox
-      padding={20}
+      padding="--spacing-core-space-5x"
       layerBlur={1}
       fill="--color-button-primary-surface-default"
     >
@@ -507,14 +503,14 @@ const EffectsTemplate: ComponentStory<typeof RadiusAutoBox> = () => (
     >
       <RadiusAutoBox
         style={{ fontWeight: 'bold' }}
-        padding={20}
+        padding="--spacing-core-space-5x"
         backgroundBlur={3}
       >
         background-blur
       </RadiusAutoBox>
     </RadiusAutoBox>
     <RadiusAutoBox
-      padding={20}
+      padding="--spacing-core-space-5x"
       layerBlur={1}
       dropShadow="--boxShadow-core-elevation-100"
       fill="--color-button-primary-surface-default"

--- a/library/core-components/components/auto-box/auto-box.styles.ts
+++ b/library/core-components/components/auto-box/auto-box.styles.ts
@@ -144,7 +144,7 @@ export const getStyles = <T extends AutoLayoutProps>({
       : `gap: ${getSize(space || 10)};`};
     ${clippedContent ? 'overflow: hidden;' : ''};
     ${padding ? `padding: ${getPadding(padding)}` : ''};
-    ${opacity !== undefined ? `opacity: ${opacity};` : ''}
+    ${opacity !== undefined ? `opacity: ${renderCSSProp(opacity)};` : ''}
     ${fill ? `background-color: ${renderCSSProp(fill)};` : ''}
     ${stroke || strokeWidth ? 'border-style: solid;' : ''}
     ${stroke ? `border-color: ${renderCSSProp(stroke)};` : ''}

--- a/library/core-components/components/auto-box/auto-box.styles.ts
+++ b/library/core-components/components/auto-box/auto-box.styles.ts
@@ -9,12 +9,10 @@ import {
   AutolayoutSize,
   Size,
   Padding,
-  Color,
   StrokeWidth,
   CornerRadius,
   HorizontalConstraint,
   VerticalConstraint,
-  Effect,
 } from './auto-box.types';
 
 export const getSize = (size?: AutolayoutSize) => {
@@ -50,15 +48,6 @@ export const getPadding = (padding?: Padding) => {
     }
   }
   return '0px';
-};
-
-export const getColor = (color?: Color) => {
-  if (typeof color === 'string') return color;
-  if (typeof color === 'object')
-    return `rgba(${color.r},${color.g},${color.b},${
-      color.a > 1 ? color.a / 100 : color.a
-    })`;
-  return 'transparent';
 };
 
 export const getStrokeWidth = (strokeWidth: StrokeWidth) => {
@@ -106,30 +95,6 @@ export const setPosition = (
   return out;
 };
 
-export const getEffects = (effect: Effect | Effect[]) => {
-  const effects = Array.isArray(effect) ? effect : [effect];
-  return effects.reduce((acc: string, effect: Effect) => {
-    switch (effect.type) {
-      case 'drop-shadow':
-        return `${acc} box-shadow: ${getCssValue(
-          effect.offset[0]
-        )} ${getCssValue(effect.offset[1])} ${getCssValue(
-          effect.blur
-        )} ${getColor(effect.color)};`;
-      case 'inner-shadow':
-        return `${acc} box-shadow: inset ${getCssValue(
-          effect.offset[0]
-        )} ${getCssValue(effect.offset[1])} ${getCssValue(
-          effect.blur
-        )} ${getColor(effect.color)};`;
-      case 'layer-blur':
-        return `${acc} filter: blur(${getCssValue(effect.blur)});`;
-      case 'background-blur':
-        return `${acc} backdrop-filter: blur(${getCssValue(effect.blur)});`;
-    }
-  }, '' as string);
-};
-
 // colours alpha can be 0-1 or 0-100
 // strokeAlign is missing middle
 // to add: strokeSide
@@ -156,7 +121,10 @@ export const getStyles = <T extends AutoLayoutProps>({
   y,
   horizontalConstraint,
   verticalConstraint,
-  effect,
+  dropShadow,
+  innerShadow,
+  layerBlur,
+  backgroundBlur,
 }: T) => {
   return css`
     display: flex;
@@ -185,7 +153,11 @@ export const getStyles = <T extends AutoLayoutProps>({
     ${x !== undefined || y !== undefined
       ? setPosition(x, y, horizontalConstraint, verticalConstraint)
       : ''}
-
-    ${effect ? getEffects(effect) : ''}
+    ${dropShadow ? `box-shadow: ${renderCSSProp(dropShadow)};` : ''}
+    ${innerShadow ? `box-shadow: inset ${renderCSSProp(innerShadow)};` : ''}
+    ${layerBlur ? `filter: blur(${getCssValue(layerBlur)});` : ''}
+    ${backgroundBlur
+      ? `backdrop-filter: blur(${getCssValue(backgroundBlur)});`
+      : ''}
   `;
 };

--- a/library/core-components/components/auto-box/auto-box.styles.ts
+++ b/library/core-components/components/auto-box/auto-box.styles.ts
@@ -10,7 +10,6 @@ import {
   Size,
   Padding,
   StrokeWidth,
-  CornerRadius,
   HorizontalConstraint,
   VerticalConstraint,
 } from './auto-box.types';
@@ -56,16 +55,6 @@ export const getStrokeWidth = (strokeWidth: StrokeWidth) => {
   return `border-width: ${getCssValue(strokeWidth.top)} ${getCssValue(
     strokeWidth.right
   )} ${getCssValue(strokeWidth.bottom)} ${getCssValue(strokeWidth.left)};`;
-};
-
-export const getCornerRadius = (cornerRadius: CornerRadius) => {
-  if (typeof cornerRadius !== 'object')
-    return `border-radius: ${getCssValue(cornerRadius)};`;
-  return `border-radius: ${getCssValue(cornerRadius.topLeft)} ${getCssValue(
-    cornerRadius.topRight
-  )} ${getCssValue(cornerRadius.bottomRight)} ${getCssValue(
-    cornerRadius.bottomLeft
-  )};`;
 };
 
 export const setPosition = (
@@ -149,7 +138,7 @@ export const getStyles = <T extends AutoLayoutProps>({
     ${stroke || strokeWidth ? 'border-style: solid;' : ''}
     ${stroke ? `border-color: ${renderCSSProp(stroke)};` : ''}
     ${strokeWidth ? getStrokeWidth(strokeWidth) : ''}
-    ${cornerRadius ? getCornerRadius(cornerRadius) : ''}
+    ${cornerRadius ? `border-radius: ${renderCSSProp(cornerRadius)}` : ''}
     ${x !== undefined || y !== undefined
       ? setPosition(x, y, horizontalConstraint, verticalConstraint)
       : ''}

--- a/library/core-components/components/auto-box/auto-box.styles.ts
+++ b/library/core-components/components/auto-box/auto-box.styles.ts
@@ -8,7 +8,6 @@ import {
   mapStrokeAlign,
   AutolayoutSize,
   Size,
-  Padding,
   HorizontalConstraint,
   VerticalConstraint,
 } from './auto-box.types';
@@ -22,29 +21,6 @@ export const getSize = (size?: AutolayoutSize) => {
 export const getCssValue = (size?: Size) => {
   if (typeof size === 'number') return `${size}px`;
   if (size) return size;
-  return '0px';
-};
-
-export const getPadding = (padding?: Padding) => {
-  if (typeof padding !== 'object' && padding !== undefined)
-    return `${getSize(padding)}`;
-  if (typeof padding === 'object') {
-    if ('vertical' in padding || 'horizontal' in padding) {
-      return `${getCssValue(padding.vertical)} ${getCssValue(
-        padding.horizontal
-      )}`;
-    }
-    if (
-      'top' in padding ||
-      'right' in padding ||
-      'bottom' in padding ||
-      'left' in padding
-    ) {
-      return `${getCssValue(padding?.top)} ${getCssValue(
-        padding.right
-      )} ${getCssValue(padding.bottom)} ${getCssValue(padding.left)}`;
-    }
-  }
   return '0px';
 };
 
@@ -125,7 +101,7 @@ export const getStyles = <T extends AutoLayoutProps>({
           space ?? { css: '10px' } // does this 10px space exist in figma?
         )};`};
     ${clippedContent ? 'overflow: hidden;' : ''};
-    ${padding ? `padding: ${getPadding(padding)}` : ''};
+    ${padding ? `padding: ${renderCSSProp(padding)}` : ''};
     ${opacity !== undefined ? `opacity: ${renderCSSProp(opacity)};` : ''}
     ${fill ? `background-color: ${renderCSSProp(fill)};` : ''}
     ${stroke || strokeWidth ? 'border-style: solid;' : ''}

--- a/library/core-components/components/auto-box/auto-box.styles.ts
+++ b/library/core-components/components/auto-box/auto-box.styles.ts
@@ -98,7 +98,7 @@ export const getStyles = <T extends AutoLayoutProps>({
     ${space === 'auto'
       ? 'justify-content: space-between;'
       : `gap: ${renderCSSProp(
-          space ?? { css: '10px' } // does this 10px space exist in figma?
+          space ?? { css: '10px' } // ? does this 10px space exist in figma or is it an artifact?
         )};`};
     ${clippedContent ? 'overflow: hidden;' : ''};
     ${padding ? `padding: ${renderCSSProp(padding)}` : ''};

--- a/library/core-components/components/auto-box/auto-box.styles.ts
+++ b/library/core-components/components/auto-box/auto-box.styles.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { renderCSSProp } from '@rangle/radius-foundations/generated/design-tokens.types';
 import './auto-box.tokens.css';
 
 import {
@@ -176,9 +177,9 @@ export const getStyles = <T extends AutoLayoutProps>({
     ${clippedContent ? 'overflow: hidden;' : ''};
     ${padding ? `padding: ${getPadding(padding)}` : ''};
     ${opacity !== undefined ? `opacity: ${opacity};` : ''}
-    ${fill ? `background-color: ${getColor(fill)};` : ''}
+    ${fill ? `background-color: ${renderCSSProp(fill)};` : ''}
     ${stroke || strokeWidth ? 'border-style: solid;' : ''}
-    ${stroke ? `border-color: ${getColor(stroke)};` : ''}
+    ${stroke ? `border-color: ${renderCSSProp(stroke)};` : ''}
     ${strokeWidth ? getStrokeWidth(strokeWidth) : ''}
     ${cornerRadius ? getCornerRadius(cornerRadius) : ''}
     ${x !== undefined || y !== undefined

--- a/library/core-components/components/auto-box/auto-box.styles.ts
+++ b/library/core-components/components/auto-box/auto-box.styles.ts
@@ -121,7 +121,9 @@ export const getStyles = <T extends AutoLayoutProps>({
       : ''};
     ${space === 'auto'
       ? 'justify-content: space-between;'
-      : `gap: ${getSize(space || 10)};`};
+      : `gap: ${renderCSSProp(
+          space ?? { css: '10px' } // does this 10px space exist in figma?
+        )};`};
     ${clippedContent ? 'overflow: hidden;' : ''};
     ${padding ? `padding: ${getPadding(padding)}` : ''};
     ${opacity !== undefined ? `opacity: ${renderCSSProp(opacity)};` : ''}

--- a/library/core-components/components/auto-box/auto-box.styles.ts
+++ b/library/core-components/components/auto-box/auto-box.styles.ts
@@ -9,7 +9,6 @@ import {
   AutolayoutSize,
   Size,
   Padding,
-  StrokeWidth,
   HorizontalConstraint,
   VerticalConstraint,
 } from './auto-box.types';
@@ -47,14 +46,6 @@ export const getPadding = (padding?: Padding) => {
     }
   }
   return '0px';
-};
-
-export const getStrokeWidth = (strokeWidth: StrokeWidth) => {
-  if (typeof strokeWidth !== 'object')
-    return `border-width: ${getCssValue(strokeWidth)};`;
-  return `border-width: ${getCssValue(strokeWidth.top)} ${getCssValue(
-    strokeWidth.right
-  )} ${getCssValue(strokeWidth.bottom)} ${getCssValue(strokeWidth.left)};`;
 };
 
 export const setPosition = (
@@ -137,7 +128,7 @@ export const getStyles = <T extends AutoLayoutProps>({
     ${fill ? `background-color: ${renderCSSProp(fill)};` : ''}
     ${stroke || strokeWidth ? 'border-style: solid;' : ''}
     ${stroke ? `border-color: ${renderCSSProp(stroke)};` : ''}
-    ${strokeWidth ? getStrokeWidth(strokeWidth) : ''}
+    ${strokeWidth ? `border-width: ${renderCSSProp(strokeWidth)};` : ''}
     ${cornerRadius ? `border-radius: ${renderCSSProp(cornerRadius)}` : ''}
     ${x !== undefined || y !== undefined
       ? setPosition(x, y, horizontalConstraint, verticalConstraint)

--- a/library/core-components/components/auto-box/auto-box.styles.ts
+++ b/library/core-components/components/auto-box/auto-box.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { renderCSSProp } from '@rangle/radius-foundations/generated/design-tokens.types';
+import { renderCSSProp } from '../../utils/design-tokens.utils';
 import './auto-box.tokens.css';
 
 import {

--- a/library/core-components/components/auto-box/auto-box.tsx
+++ b/library/core-components/components/auto-box/auto-box.tsx
@@ -7,13 +7,13 @@ import { elementAndProps } from '../../utils/polymorphic.utils';
 import { AutoLayoutProps } from './auto-box.types';
 import { getStyles } from './auto-box.styles';
 
-type RadiusButtonTag = React.ElementType;
+type RadiusAutoBoxTag = React.ElementType;
 export type RadiusAutoBoxProps = PolymorphicComponentPropWithRef<
   React.ElementType,
   AutoLayoutProps
 >;
 
-export const RadiusAutoBox = forwardRef<RadiusButtonTag, RadiusAutoBoxProps>(
+export const RadiusAutoBox = forwardRef<RadiusAutoBoxTag, RadiusAutoBoxProps>(
   (
     {
       children,

--- a/library/core-components/components/auto-box/auto-box.types.ts
+++ b/library/core-components/components/auto-box/auto-box.types.ts
@@ -32,15 +32,20 @@ export type AutoLayoutProps = {
   horizontalConstraint?: HorizontalConstraint;
   verticalConstraint?: VerticalConstraint;
 
-  fill?: CSSProp<'color', 'background' | 'interaction'>;
-  stroke?: CSSProp<'color', 'background' | 'interaction'>;
+  fill?: CSSProp<'color'>;
+  stroke?: CSSProp<'color'>;
   strokeWidth?: StrokeWidth;
   strokeAlign?: StrokeAlign;
   // strokeSide?: StrokeSide;
   // strokeCap?: StrokeCap;
 
   cornerRadius?: CornerRadius;
-  effect?: Effect | Effect[];
+
+  // effects
+  dropShadow?: DropShadow;
+  innerShadow?: InnerShadow;
+  layerBlur?: Blur;
+  backgroundBlur?: Blur;
 
   // blendMode?: BlendMode; // not needed
 };
@@ -62,36 +67,11 @@ export type BlendMode =
   | 'color'
   | 'luminosity';
 
-type Vector = readonly [x: Size, y: Size];
-type HexCode = `#${string}`;
-export type Color =
-  | {
-      r: number;
-      g: number;
-      b: number;
-      a: number;
-    }
-  | `var(${string})`
-  | HexCode;
-
-export type Effect = DropShadowEffect | InnerShadowEffect | BlurEffect;
-
-type DropShadowEffect = {
-  type: 'drop-shadow';
-  color: HexCode | Color;
-  offset: Vector;
-  blur: Size;
-};
-type InnerShadowEffect = {
-  type: 'inner-shadow';
-  color: HexCode | Color;
-  offset: Vector;
-  blur: Size;
-};
-type BlurEffect = {
-  type: 'layer-blur' | 'background-blur';
-  blur: Size;
-};
+// effects
+// TODO: narrow these types (in generator)
+export type DropShadow = CSSProp;
+export type InnerShadow = CSSProp;
+export type Blur = Size;
 
 type StrokeSides = 'top' | 'left' | 'bottom' | 'right';
 export type StrokeWidth = Size | { [key in StrokeSides]: Size };

--- a/library/core-components/components/auto-box/auto-box.types.ts
+++ b/library/core-components/components/auto-box/auto-box.types.ts
@@ -25,7 +25,7 @@ export type AutoLayoutProps = {
   height?: AutolayoutSize;
 
   padding?: Padding;
-  opacity?: number;
+  opacity?: CSSProp; // TODO: narrow this type
 
   x?: Size;
   y?: Size;

--- a/library/core-components/components/auto-box/auto-box.types.ts
+++ b/library/core-components/components/auto-box/auto-box.types.ts
@@ -18,7 +18,7 @@ export type AutoLayoutProps = {
   isParent?: boolean;
   absolutePosition?: boolean;
   direction?: 'horizontal' | 'vertical';
-  space?: Size | 'auto'; //number is considered fixed auto is justify-content: space-between;
+  space?: CSSProp<'spacing'> | 'auto'; // auto = justify-content: space-between;
   clippedContent?: boolean;
   alignment?: keyof typeof mapAlignments;
   width?: AutolayoutSize;

--- a/library/core-components/components/auto-box/auto-box.types.ts
+++ b/library/core-components/components/auto-box/auto-box.types.ts
@@ -1,3 +1,5 @@
+import { CSSProp } from '@rangle/radius-foundations/generated/design-tokens.types';
+
 export const mapAlignments = {
   top: 'flex-start',
   center: 'center',
@@ -30,8 +32,8 @@ export type AutoLayoutProps = {
   horizontalConstraint?: HorizontalConstraint;
   verticalConstraint?: VerticalConstraint;
 
-  fill?: Color;
-  stroke?: Color;
+  fill?: CSSProp<'color', 'background' | 'interaction'>;
+  stroke?: CSSProp<'color', 'background' | 'interaction'>;
   strokeWidth?: StrokeWidth;
   strokeAlign?: StrokeAlign;
   // strokeSide?: StrokeSide;

--- a/library/core-components/components/auto-box/auto-box.types.ts
+++ b/library/core-components/components/auto-box/auto-box.types.ts
@@ -34,7 +34,7 @@ export type AutoLayoutProps = {
 
   fill?: CSSProp<'color'>;
   stroke?: CSSProp<'color'>;
-  strokeWidth?: StrokeWidth;
+  strokeWidth?: CSSProp; // TODO: narrow this type
   strokeAlign?: StrokeAlign;
   // strokeSide?: StrokeSide;
   // strokeCap?: StrokeCap;
@@ -72,9 +72,6 @@ export type BlendMode =
 export type DropShadow = CSSProp;
 export type InnerShadow = CSSProp;
 export type Blur = Size;
-
-type StrokeSides = 'top' | 'left' | 'bottom' | 'right';
-export type StrokeWidth = Size | { [key in StrokeSides]: Size };
 
 export type Size = number | `${number}px` | `${number}%` | `var(${string})`;
 export type AutolayoutSize = Size | 'fill-parent' | 'hug-contents';

--- a/library/core-components/components/auto-box/auto-box.types.ts
+++ b/library/core-components/components/auto-box/auto-box.types.ts
@@ -24,7 +24,7 @@ export type AutoLayoutProps = {
   width?: AutolayoutSize;
   height?: AutolayoutSize;
 
-  padding?: Padding;
+  padding?: CSSProp<'spacing'>;
   opacity?: CSSProp; // TODO: narrow this type
 
   x?: Size;
@@ -96,15 +96,3 @@ export type VerticalConstraint =
   | 'top and bottom'
   | 'center'
   | 'scale';
-
-type FullPadding = {
-  top?: Size;
-  left?: Size;
-  bottom?: Size;
-  right?: Size;
-};
-type VerticalHorizontalPadding = {
-  vertical?: Size;
-  horizontal?: Size;
-};
-export type Padding = Size | FullPadding | VerticalHorizontalPadding;

--- a/library/core-components/components/auto-box/auto-box.types.ts
+++ b/library/core-components/components/auto-box/auto-box.types.ts
@@ -39,7 +39,7 @@ export type AutoLayoutProps = {
   // strokeSide?: StrokeSide;
   // strokeCap?: StrokeCap;
 
-  cornerRadius?: CornerRadius;
+  cornerRadius?: CSSProp; // TODO: narrow this type
 
   // effects
   dropShadow?: DropShadow;
@@ -99,15 +99,6 @@ export type VerticalConstraint =
   | 'top and bottom'
   | 'center'
   | 'scale';
-
-export type CornerRadius =
-  | Size
-  | {
-      topLeft?: Size;
-      topRight?: Size;
-      bottomLeft?: Size;
-      bottomRight?: Size;
-    };
 
 type FullPadding = {
   top?: Size;

--- a/library/core-components/components/button/button.styles.ts
+++ b/library/core-components/components/button/button.styles.ts
@@ -1,6 +1,7 @@
-import { css, CSSObject } from '@emotion/css';
+import { css } from '@emotion/css';
 import {
   RadiusSpacingTokens,
+  RadiusColorTokens,
   Var,
 } from '@rangle/radius-foundations/generated/design-tokens.types';
 // Discrimitated unions are an excellent way to add type safety
@@ -48,7 +49,9 @@ const buttonSize: Record<
  */
 const buttonColors: Record<
   RadiusButtonStyleType,
-  Pick<CSSObject, 'color' | 'background' | 'border'>
+  {
+    [key in 'color' | 'background' | 'border']: Var<RadiusColorTokens>;
+  }
 > = {
   filled: {
     color: 'var(--color-button-primary-label-default)',

--- a/library/core-components/components/hero/hero.tsx
+++ b/library/core-components/components/hero/hero.tsx
@@ -38,12 +38,12 @@ export const RadiusHero = ({
         <RadiusAutoBox direction="vertical" className="text-container">
           <Typography
             as="p"
-            font="var(--typography-heading-md)"
-            color="var(--color-text-on-base-secondary)"
+            font="--typography-heading-md"
+            color="--color-text-on-base-secondary"
           >
             {eyebrow}
           </Typography>
-          <Typography as="h1" font="var(--typography-heading-xxl)">
+          <Typography as="h1" font="--typography-heading-xxl">
             {title}
           </Typography>
           <RadiusAutoBox className="buttonContainer">

--- a/library/core-components/components/text-and-image/text-and-image.tsx
+++ b/library/core-components/components/text-and-image/text-and-image.tsx
@@ -38,15 +38,15 @@ export const TextAndImage = forwardRef<React.ElementType, TextAndImageProps>(
           {/* Title */}
           <Typography
             as={headingLevel}
-            font="var(--typography-heading-lg)"
-            color="var(--color-text-on-base-primary)"
+            font="--typography-heading-lg"
+            color="--color-text-on-base-primary"
           >
             {title}
           </Typography>
           {/* Body */}
           <Typography
-            font="var(--typography-body-md)"
-            color="var(--color-text-on-base-secondary)"
+            font="--typography-body-md"
+            color="--color-text-on-base-secondary"
           >
             {body}
           </Typography>

--- a/library/core-components/components/typography/typography.stories.tsx
+++ b/library/core-components/components/typography/typography.stories.tsx
@@ -26,10 +26,10 @@ export default {
       defaultValue: 'left',
     },
     color: {
-      defaultValue: 'var(--color-text-on-base-primary)',
+      defaultValue: '--color-text-on-base-primary',
     },
     font: {
-      defaultValue: 'var(--typography-body-md)',
+      defaultValue: '--typography-body-md',
     },
   },
 } as ComponentMeta<typeof Typography>;
@@ -43,14 +43,14 @@ Default.args = {};
 
 export const Example: ComponentStory<typeof Typography> = () => (
   <div>
-    <Typography font="var(--typography-heading-xl)">Title</Typography>
-    <Typography color="var(--color-text-on-base-accent)">
+    <Typography font="--typography-heading-xl">Title</Typography>
+    <Typography color="--color-text-on-base-accent">
       Some body text. Lorem ipsum dolor sit, amet consectetur adipisicing elit.
       Fuga, blanditiis.
     </Typography>
     <Typography
-      font="var(--typography-body-sm)"
-      color="var(--color-text-on-base-secondary)"
+      font="--typography-body-sm"
+      color="--color-text-on-base-secondary"
       align="right"
     >
       *Footnote

--- a/library/core-components/components/typography/typography.styles.ts
+++ b/library/core-components/components/typography/typography.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { renderCSSProp } from '@rangle/radius-foundations/generated/design-tokens.types';
+import { renderCSSProp } from '../../utils/design-tokens.utils';
 import { TypographyExtendedProps } from './typography';
 
 export type StylesProps = Pick<

--- a/library/core-components/components/typography/typography.styles.ts
+++ b/library/core-components/components/typography/typography.styles.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { renderCSSProp } from '@rangle/radius-foundations/generated/design-tokens.types';
 import { TypographyExtendedProps } from './typography';
 
 export type StylesProps = Pick<
@@ -6,11 +7,15 @@ export type StylesProps = Pick<
   'align' | 'color' | 'font'
 >;
 
-export const getStyles = <T extends StylesProps>({ align, color, font }: T) => {
+export const getStyles = ({
+  align = 'left',
+  color = '--color-text-on-base-primary',
+  font = '--typography-body-md',
+}: StylesProps) => {
   return css`
-    color: ${color};
+    color: ${renderCSSProp(color)};
     text-align: ${align};
-    font: ${font};
+    font: ${renderCSSProp(font)};
     margin: 0;
     padding: 0;
   `;

--- a/library/core-components/components/typography/typography.tsx
+++ b/library/core-components/components/typography/typography.tsx
@@ -1,10 +1,6 @@
 import React, { useMemo, forwardRef } from 'react';
 import { cx } from '@emotion/css';
-import {
-  RadiusColorTokens,
-  RadiusTypographyTokens,
-  Var,
-} from '@rangle/radius-foundations/generated/design-tokens.types';
+import { CSSProp } from '@rangle/radius-foundations/generated/design-tokens.types';
 
 import { PolymorphicComponentPropWithRef } from '../../utils/polymorphic.types';
 import { elementAndProps } from '../../utils/polymorphic.utils';
@@ -34,9 +30,9 @@ export type TypographyExtendedProps = {
   /** Text alignment */
   align?: Alignment;
   /** Text color */
-  color?: Var<RadiusColorTokens>; // ? How to handle optional string values? This completely invalidates the type safety & intellisense value of the design token types
+  color?: CSSProp<'color', 'text'>;
   /** Font (css shorthand property - see https://developer.mozilla.org/en-US/docs/Web/CSS/font) */
-  font?: Var<RadiusTypographyTokens>;
+  font?: CSSProp<'typography'>;
   children: React.ReactNode;
 };
 
@@ -51,17 +47,7 @@ export type TypographyProps = PolymorphicComponentPropWithRef<
  * declared in the Specific Props type above.
  */
 export const Typography = forwardRef<TypographyTag, TypographyProps>(
-  (
-    {
-      align = 'left',
-      color = 'var(--color-text-on-base-primary)',
-      font = 'var(--typography-body-md)',
-      children,
-      className,
-      ...rest
-    }: TypographyProps,
-    ref
-  ) => {
+  ({ align, color, font, children, className, ...rest }, ref) => {
     const element = elementAndProps(rest, ref, 'p');
 
     const style = useMemo(

--- a/library/core-components/utils/design-tokens.utils.ts
+++ b/library/core-components/utils/design-tokens.utils.ts
@@ -1,0 +1,8 @@
+import type {
+  CSSExpression,
+  RadiusTokens,
+} from '@rangle/radius-foundations/generated/design-tokens.types';
+
+// TODO: use this function in `library/foundations/src/utils/design-tokens.utils.ts` - this is temporary while we figure out how to fix the build failure caused by importing it
+export const renderCSSProp = (prop: RadiusTokens | { css: CSSExpression }) =>
+  typeof prop === 'string' ? `var(${prop})` : prop.css;

--- a/library/core-components/utils/utils.test.ts
+++ b/library/core-components/utils/utils.test.ts
@@ -1,0 +1,20 @@
+import { renderCSSProp } from './design-tokens.utils';
+
+describe('utils', () => {
+  describe('design-tokens.utils', () => {
+    describe('renderCSSProp', () => {
+      it('should return a CSS variable when passed a string', () => {
+        expect(renderCSSProp('--color-text-on-base-primary')).toBe(
+          'var(--color-text-on-base-primary)'
+        );
+      });
+      it('should return a CSS expression when passed an object', () => {
+        expect(
+          renderCSSProp({
+            css: '1px solid red',
+          })
+        ).toBe('1px solid red');
+      });
+    });
+  });
+});

--- a/library/foundations/package.json
+++ b/library/foundations/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@rangle/radius-foundations",
   "version": "1.1.0",
+  "main": "src/index.ts",
   "description": "Foundation scripts and variables for Design Systems",
   "files": [
     "docs/",
-    "generated/"
+    "generated/",
+    "src/"
   ],
   "types": "generated/design-tokens.types.ts",
   "repository": {

--- a/library/foundations/scripts/templates/token-types.template.ts
+++ b/library/foundations/scripts/templates/token-types.template.ts
@@ -81,6 +81,19 @@ export const renderTokenTypes = ({ order, layers }: TokenLayers) => {
       .join('\n')};
 
   // Tokens By Subject (--color-button, --typography-button, etc.)
+
+    export type CSSTokenSubjects =
+      | 'text'
+      | 'background'
+      | 'interaction'
+      | 'section'
+      | 'heading'
+      | 'body'
+      | 'link'
+      | 'btn'
+      | 'screen'
+      | 'button';
+
     ${subjectNames
       .map(
         (subject) => `
@@ -90,6 +103,46 @@ export const renderTokenTypes = ({ order, layers }: TokenLayers) => {
       Extract<RadiusTokens, \`--\${T}-${subject}-\${string}\`>;`
       )
       .join('\n')};
+
+
+  // Utilities
+
+  type CSSExpression =
+    | string
+    | number
+    | boolean
+    | null
+    | undefined
+    | CSSExpression[]
+    | { [key: string]: CSSExpression };
+
+  export const renderCSSProp = (prop: RadiusTokens | { css: CSSExpression }) =>
+    typeof prop === 'string' ? \`var(\${prop})\` : prop.css;
+
+  /**
+   * Returns a list of tokens that match the given type T and subject S. If no subject is provided, all subjects are returned, and if no type is provided, all types are returned.
+   *
+   * There can be multiple subjects for a given type, so for example you may have \`--color-text-primary\` and \`--color-background-primary\`, or \`--typography-heading-sm\` and \`--typography-body-sm\`.
+   *
+   * @example
+   * CSSProp<'color', 'text'> // returns \`--color-text-\${string}\`
+   * CSSProp<'typography'>; // returns \`--typography-\${string}\`
+   */
+  export type CSSTokensByTypeAndSubject<
+    T extends RadiusTokenTypes = RadiusTokenTypes,
+    S extends CSSTokenSubjects = CSSTokenSubjects
+  > = Extract<RadiusTokens, \`--\${T}-\${S}-\${string}\`>;
+
+  /** Returns a list of tokens tokens as described by {@link CSSTokensByTypeAndSubject}, or a custom CSS expression provided inside an object with the css property.
+   * @example
+   * <Typography color="--color-primary-base-500" font="--typography-base-lg" />
+   * // vs:
+   * <Typography color={{ css: "red" }} font={{ css: "Arial" }} />
+   */
+  export type CSSProp<
+    T extends RadiusTokenTypes = RadiusTokenTypes,
+    S extends CSSTokenSubjects = CSSTokenSubjects
+  > = CSSTokensByTypeAndSubject<T, S> | { css: CSSExpression };
 
   /** Utility type that returns the provided token type(s) wrapped with the \`var()\` function. */
   export type Var<T> = T extends string ? \`var(\${T})\` : T;

--- a/library/foundations/scripts/templates/token-types.template.ts
+++ b/library/foundations/scripts/templates/token-types.template.ts
@@ -80,19 +80,13 @@ export const renderTokenTypes = ({ order, layers }: TokenLayers) => {
       )
       .join('\n')};
 
-  // Tokens By Subject (--color-button, --typography-button, etc.)
+  // Token Subjects
 
-    export type CSSTokenSubjects =
-      | 'text'
-      | 'background'
-      | 'interaction'
-      | 'section'
-      | 'heading'
-      | 'body'
-      | 'link'
-      | 'btn'
-      | 'screen'
-      | 'button';
+  export type RadiusTokenSubjects = ${subjectNames
+    .map((subject) => `'${subject}'`)
+    .join(' | ')};
+
+  // Tokens By Subject (--color-button, --typography-button, etc.)
 
     ${subjectNames
       .map(
@@ -119,6 +113,7 @@ export const renderTokenTypes = ({ order, layers }: TokenLayers) => {
   export const renderCSSProp = (prop: RadiusTokens | { css: CSSExpression }) =>
     typeof prop === 'string' ? \`var(\${prop})\` : prop.css;
 
+
   /**
    * Returns a list of tokens that match the given type T and subject S. If no subject is provided, all subjects are returned, and if no type is provided, all types are returned.
    *
@@ -130,8 +125,9 @@ export const renderTokenTypes = ({ order, layers }: TokenLayers) => {
    */
   export type CSSTokensByTypeAndSubject<
     T extends RadiusTokenTypes = RadiusTokenTypes,
-    S extends CSSTokenSubjects = CSSTokenSubjects
+    S extends RadiusTokenSubjects = RadiusTokenSubjects
   > = Extract<RadiusTokens, \`--\${T}-\${S}-\${string}\`>;
+
 
   /** Returns a list of tokens tokens as described by {@link CSSTokensByTypeAndSubject}, or a custom CSS expression provided inside an object with the css property.
    * @example
@@ -141,8 +137,9 @@ export const renderTokenTypes = ({ order, layers }: TokenLayers) => {
    */
   export type CSSProp<
     T extends RadiusTokenTypes = RadiusTokenTypes,
-    S extends CSSTokenSubjects = CSSTokenSubjects
+    S extends RadiusTokenSubjects = RadiusTokenSubjects
   > = CSSTokensByTypeAndSubject<T, S> | { css: CSSExpression };
+
 
   /** Utility type that returns the provided token type(s) wrapped with the \`var()\` function. */
   export type Var<T> = T extends string ? \`var(\${T})\` : T;

--- a/library/foundations/scripts/templates/token-types.template.ts
+++ b/library/foundations/scripts/templates/token-types.template.ts
@@ -101,7 +101,7 @@ export const renderTokenTypes = ({ order, layers }: TokenLayers) => {
 
   // Utilities
 
-  type CSSExpression =
+  export type CSSExpression =
     | string
     | number
     | boolean
@@ -109,9 +109,6 @@ export const renderTokenTypes = ({ order, layers }: TokenLayers) => {
     | undefined
     | CSSExpression[]
     | { [key: string]: CSSExpression };
-
-  export const renderCSSProp = (prop: RadiusTokens | { css: CSSExpression }) =>
-    typeof prop === 'string' ? \`var(\${prop})\` : prop.css;
 
 
   /**

--- a/library/foundations/src/index.ts
+++ b/library/foundations/src/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/library/foundations/src/utils/design-tokens.utils.ts
+++ b/library/foundations/src/utils/design-tokens.utils.ts
@@ -1,0 +1,8 @@
+import type {
+  CSSExpression,
+  RadiusTokens,
+} from '../../generated/design-tokens.types';
+
+// TODO: fix imports from `core-components` (currently causes build failure). For now this is unused in favor of a copy here: `library/core-components/utils/design-tokens.utils.ts`
+export const renderCSSProp = (prop: RadiusTokens | { css: CSSExpression }) =>
+  typeof prop === 'string' ? `var(${prop})` : prop.css;

--- a/library/foundations/src/utils/index.ts
+++ b/library/foundations/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './design-tokens.utils';


### PR DESCRIPTION
Added a new type utility `CSSProp` which will return the specified token types & subjects, along with a `{ css: CSSExpression }` object to allow custom properties to be used.

## Todo
- [ ] Resolve build failure:
  <img width="903" alt="Screenshot 2023-03-13 at 2 51 04 PM" src="https://user-images.githubusercontent.com/23023263/224800887-41546577-52fa-436c-80f7-dbd6bcf6a26d.png">
    - note this has something to do with the imported `renderCSSProp` in `typography.styles.ts`
- [x] refactor AutoBox to use the new type (in progress)
- [ ] Figure out polymorphic issues
  - AutoBox props not providing type safety
  - typography `color` prop expecting string type erroneously
- [ ] Ensure story controls work correctly
- [x] tests

note: the remaining issues will be handled separately. I've moved the function causing the build failure to the `core-components` package as a temporary workaround.

## Questions
- [x] Is it actually valuable to allow css properties in these fields (vs. tokens only)?
  - We can already override styles by using `className` or `styles` prop which may be cleaner
- [x] is there a reason to keep AutoBox `effects` as its own prop with nested properties? Or can we create individual props? Individual would be cleaner for use with tokens
- [x] Where should we be recording missing or incorrect tokens?