### PR TITLE
Update demo app comment to only be created once per PR

### DIFF
--- a/.github/workflows/build-chromatic.yml
+++ b/.github/workflows/build-chromatic.yml
@@ -60,7 +60,7 @@ jobs:
         run: yarn test -- --coverage
 
       - name: Coverage Report
-        uses: vebr/jest-lcov-reporter@v0.2.0
+        uses: vebr/jest-lcov-reporter@v0.2.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           lcov-file: ./coverage/lcov.info

--- a/.github/workflows/build-chromatic.yml
+++ b/.github/workflows/build-chromatic.yml
@@ -79,7 +79,7 @@ jobs:
         id: chromatic
 
       # Find existing Chromatic URL comment
-      - name: Find Comment
+      - name: Find Existing Comment
         uses: peter-evans/find-comment@v2
         id: fc
         with:

--- a/.github/workflows/deployment-pr.yml
+++ b/.github/workflows/deployment-pr.yml
@@ -59,9 +59,20 @@ jobs:
       - name: Deploy Demo App to AWS
         run: yarn sst deploy --stage radius-pr
 
+      # Find existing Demo App comment
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Demo App Preview
+
+      # Create new comment with Demo App URL, if one does not exist already
       - name: Comment on PR with link to deployed demo app
-        uses: peter-evans/create-or-update-comment@v1
+        if: steps.fc.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Preview the demo app on https://d11mwnosflssyy.cloudfront.net/
+            Demo App Preview: https://d11mwnosflssyy.cloudfront.net/

--- a/.github/workflows/deployment-pr.yml
+++ b/.github/workflows/deployment-pr.yml
@@ -60,7 +60,7 @@ jobs:
         run: yarn sst deploy --stage radius-pr
 
       # Find existing Demo App comment
-      - name: Find Comment
+      - name: Find Existing Comment
         uses: peter-evans/find-comment@v2
         id: fc
         with:


### PR DESCRIPTION
Previously, for each new new push to a PR, a new comment would be created with a link to the demo app which cluttered the timeline. This change means that only one comment will be made on a PR.

Note: also updated coverage reporter version in attempt to fix duplicate coverage comments