### PR TITLE
Icon token refactor

### DIFF
--- a/library/core-components/components/hero/hero.tsx
+++ b/library/core-components/components/hero/hero.tsx
@@ -38,18 +38,25 @@ export const RadiusHero = ({
         <RadiusAutoBox direction="vertical" className="text-container">
           <Typography
             as="p"
+            // @ts-expect-error TODO: fix this when we have the correct component tokens
             font="--typography-heading-md"
+            // @ts-expect-error TODO: fix this when we have the correct component tokens
             color="--color-text-on-base-secondary"
           >
             {eyebrow}
           </Typography>
-          <Typography as="h1" font="--typography-heading-xxl">
+          <Typography
+            as="h1"
+            // @ts-expect-error TODO: fix this when we have the correct component tokens
+            font="--typography-heading-xxl"
+          >
             {title}
           </Typography>
           <RadiusAutoBox className="buttonContainer">
             <RadiusButton
               as="a"
               variant="primary"
+              // @ts-expect-error TODO: fix this when we have the correct component tokens
               size="large"
               href={ctaUrl}
               // TODO: remove this className when the link button bug (R20-218) is fixed

--- a/library/core-components/components/icon/icon.stories.tsx
+++ b/library/core-components/components/icon/icon.stories.tsx
@@ -114,6 +114,7 @@ export const AllIcons: Story = {
               height: '85px',
             }}
           >
+            {/* @ts-expect-error - incorrect args type (possibly?) means that the component doesn't think it's getting required props. Bug: BOOST-232 */}
             <RadiusIcon component={icon} {...args} />
             <span
               style={{

--- a/library/core-components/components/icon/icon.stories.tsx
+++ b/library/core-components/components/icon/icon.stories.tsx
@@ -3,6 +3,8 @@ import { Meta, StoryObj, ArgTypes, Args } from '@storybook/react';
 
 import { RadiusIcon } from '.';
 import * as icons from '@rangle/radius-foundations/generated/icons';
+import { radiusTokens } from '@rangle/radius-foundations/generated/design-tokens.constants';
+import { flattenObject } from '../../utils/flatten.utils';
 
 const meta: Meta<typeof RadiusIcon> = {
   component: RadiusIcon,
@@ -20,72 +22,19 @@ const meta: Meta<typeof RadiusIcon> = {
       control: {
         type: 'select',
       },
-      options: [
-        '--color-text-on-base-primary',
-        '--color-text-on-base-secondary',
-        '--color-text-on-base-accent',
-        '--color-text-on-base-disabled',
-        '--color-text-inverse-primary',
-        '--color-text-inverse-secondary',
-        '--color-text-inverse-accent',
-        '--color-text-on-subtle-primary',
-        '--color-text-on-subtle-secondary',
-        '--color-text-on-subtle-accent',
-        '--color-text-on-subtle-disabled',
-        '--color-text-on-accent-primary',
-        '--color-text-on-accent-secondary',
-        '--color-text-on-accent-disabled',
-        '--color-text-primary-action-default',
-        '--color-text-primary-action-hover',
-        '--color-text-primary-action-active',
-        '--color-text-primary-action-focus',
-        '--color-text-primary-action-disabled',
-        '--color-text-secondary-action-default',
-        '--color-text-secondary-action-hover',
-        '--color-text-secondary-action-active',
-        '--color-text-secondary-action-focus',
-        '--color-text-secondary-action-disabled',
-        '--color-text-tertiary-action-default',
-        '--color-text-tertiary-action-hover',
-        '--color-text-tertiary-action-active',
-        '--color-text-tertiary-action-focus',
-        '--color-text-tertiary-action-disabled',
-        '--color-background-base',
-        '--color-background-subtle',
-        '--color-background-accent',
-        '--color-background-inverse',
-        '--color-interaction-primary-default',
-        '--color-interaction-primary-hover',
-        '--color-interaction-primary-active',
-        '--color-interaction-primary-focus',
-        '--color-interaction-primary-disabled',
-        '--color-interaction-secondary-default',
-        '--color-interaction-secondary-hover',
-        '--color-interaction-secondary-active',
-        '--color-interaction-secondary-focus',
-        '--color-interaction-secondary-disabled',
-        '--color-interaction-tertiary-default',
-        '--color-interaction-tertiary-hover',
-        '--color-interaction-tertiary-active',
-        '--color-interaction-tertiary-focus',
-        '--color-interaction-tertiary-disabled',
-      ],
+      options: flattenObject(radiusTokens.component.color),
       defaultValue: 'currentColor',
     },
     size: {
       control: {
         type: 'select',
       },
-      options: [
-        '--sizing-semantic-sizing-images-and-icons-icons-default',
-        '--sizing-semantic-sizing-images-and-icons-icons-large',
-        '--sizing-semantic-sizing-images-and-icons-icons-huge',
-      ],
+      options: Object.values(radiusTokens.semantic.sizing.imagesAndIcons.icons),
     },
   } as ArgTypes,
   args: {
-    fill: '--color-text-on-base-primary',
-    size: '--sizing-semantic-sizing-images-and-icons-icons-default',
+    fill: radiusTokens.component.color.button.secondary.default.label,
+    size: radiusTokens.semantic.sizing.imagesAndIcons.icons.default,
   } as Args,
 };
 

--- a/library/core-components/components/icon/icon.stories.tsx
+++ b/library/core-components/components/icon/icon.stories.tsx
@@ -72,10 +72,20 @@ const meta: Meta<typeof RadiusIcon> = {
       ],
       defaultValue: 'currentColor',
     },
+    size: {
+      control: {
+        type: 'select',
+      },
+      options: [
+        '--sizing-semantic-sizing-images-and-icons-icons-default',
+        '--sizing-semantic-sizing-images-and-icons-icons-large',
+        '--sizing-semantic-sizing-images-and-icons-icons-huge',
+      ],
+    },
   } as ArgTypes,
   args: {
     fill: '--color-text-on-base-primary',
-    size: 'medium',
+    size: '--sizing-semantic-sizing-images-and-icons-icons-default',
   } as Args,
 };
 

--- a/library/core-components/components/icon/icon.stories.tsx
+++ b/library/core-components/components/icon/icon.stories.tsx
@@ -68,6 +68,7 @@ export const AllIcons: Story = {
             <span
               style={{
                 font: '400 0.75rem/150% Riforma LL',
+                color: `var(${radiusTokens.component.color.button.secondary.default.label})`,
               }}
             >
               {iconName}

--- a/library/core-components/components/icon/icon.styles.ts
+++ b/library/core-components/components/icon/icon.styles.ts
@@ -2,11 +2,13 @@ import { css } from '@emotion/css';
 import { renderCSSProp } from '../../utils/design-tokens.utils';
 import { RadiusIconProps } from './icon.types';
 
-type IconProps = Pick<RadiusIconProps, 'fill'>;
+type IconProps = Pick<RadiusIconProps, 'fill' | 'size'>;
 
 /** returns the className generated for the styles of this component */
-export const getStyles = ({ fill }: IconProps) => {
+export const getStyles = ({ fill, size }: IconProps) => {
   return css`
     fill: ${renderCSSProp(fill) ?? 'currentColor'};
+    width: ${renderCSSProp(size)};
+    height: ${renderCSSProp(size)};
   `;
 };

--- a/library/core-components/components/icon/icon.tsx
+++ b/library/core-components/components/icon/icon.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, useMemo } from 'react';
 import { cx } from '@emotion/css';
 
 import { getStyles } from './icon.styles';
-import { RadiusIconProps, ICON_SIZES } from './icon.types';
+import { RadiusIconProps } from './icon.types';
 import { withIcon } from './utils';
 
 /**
@@ -23,21 +23,15 @@ import { withIcon } from './utils';
  * means that the icon will inherit the color of the parent element.
  */
 export const RadiusIcon = forwardRef<SVGSVGElement, RadiusIconProps>(
-  ({ component, path, size = 'medium', fill, className, ...rest }, ref) => {
-    const styles = useMemo(() => getStyles({ fill }), [fill]);
+  ({ component, path, size, fill, className, ...rest }, ref) => {
+    const styles = useMemo(() => getStyles({ fill, size }), [fill, size]);
     const IconComponent = useMemo(
       () => (component ? component : withIcon(path)),
       [component, path]
     );
 
     return (
-      <IconComponent
-        className={cx(styles, className)}
-        width={ICON_SIZES[size]}
-        height={ICON_SIZES[size]}
-        ref={ref}
-        {...rest}
-      />
+      <IconComponent className={cx(styles, className)} ref={ref} {...rest} />
     );
   }
 );

--- a/library/core-components/components/icon/icon.tsx
+++ b/library/core-components/components/icon/icon.tsx
@@ -6,21 +6,22 @@ import { RadiusIconProps } from './icon.types';
 import { withIcon } from './utils';
 
 /**
- * A component that renders an svg icon and exposes all the attributes of the svg tag along with custom
- * attributes like size and fill.
+ * A component that renders an svg icon and exposes all the attributes of the
+ * svg tag along with custom attributes like size and fill.
  *
  * It can be used in two ways:
  *
- * 1. by passing an SVG component using the `component` prop, like those generated in
- * `'@rangle/radius-foundations/generated/icons'`.
- * 2. by passing the path of the icon as a string using the `path` prop. This is useful when you want
- * to use an icon that is not in the library.
+ * 1. by passing an SVG component using the `component` prop, like those
+ * generated in `'@rangle/radius-foundations/generated/icons'`.
+ * 2. by passing the path of the icon as a string using the `path` prop. This is
+ * useful when you want to use an icon that is not in the library.
  *
- * The component will automatically set the width and height of the svg to the size specified in the
- * `size` prop. The default size is `medium`.
+ * The component will automatically set the width and height of the svg to the
+ * size specified in the `size` prop.
  *
- * The `fill` prop can be used to set the color of the icon. The default color is `currentColor`, which
- * means that the icon will inherit the color of the parent element.
+ * The `fill` prop can be used to set the color of the icon. The default color
+ * is `currentColor`, which means that the icon will inherit the color of the
+ * parent element.
  */
 export const RadiusIcon = forwardRef<SVGSVGElement, RadiusIconProps>(
   ({ component, path, size, fill, className, ...rest }, ref) => {

--- a/library/core-components/components/icon/icon.types.ts
+++ b/library/core-components/components/icon/icon.types.ts
@@ -30,9 +30,9 @@ type ExclusiveProps = ComponentProps | PathProps;
 /** Custom props extending the functionality of the base svg component */
 type RadiusIconExtendedProps = {
   /** Icon size. Will automatically set the `width` and `height` of the SVG */
-  size: CSSProp<'sizing', 'semantic'>;
+  size: CSSProp<'sizing', 'semantic' | 'component'>;
   /** Icon fill color. Defaults to `currentColor` so that the icon will inherit the color of the parent element */
-  fill?: CSSProp<'color'>;
+  fill?: CSSProp<'color', 'component'>;
   /** Custom class name to override styling if needed */
   className?: string;
 } & ExclusiveProps;

--- a/library/core-components/components/icon/icon.types.ts
+++ b/library/core-components/components/icon/icon.types.ts
@@ -1,11 +1,5 @@
 import { CSSProp } from '@rangle/radius-foundations';
 
-export const ICON_SIZES = {
-  small: 16,
-  medium: 24,
-  large: 32,
-} as const;
-
 type ComponentProps = {
   /** The React SVG component to render. Mutually exclusive with `path` prop */
   component: React.ComponentType<React.SVGProps<SVGSVGElement>>;
@@ -36,7 +30,7 @@ type ExclusiveProps = ComponentProps | PathProps;
 /** Custom props extending the functionality of the base svg component */
 type RadiusIconExtendedProps = {
   /** Icon size. Will automatically set the `width` and `height` of the SVG */
-  size?: keyof typeof ICON_SIZES;
+  size: CSSProp<'sizing', 'semantic'>;
   /** Icon fill color. Defaults to `currentColor` so that the icon will inherit the color of the parent element */
   fill?: CSSProp<'color'>;
   /** Custom class name to override styling if needed */

--- a/library/core-components/components/icon/icon.types.ts
+++ b/library/core-components/components/icon/icon.types.ts
@@ -3,7 +3,8 @@ import { CSSProp } from '@rangle/radius-foundations';
 type ComponentProps = {
   /** The React SVG component to render. Mutually exclusive with `path` prop */
   component: React.ComponentType<React.SVGProps<SVGSVGElement>>;
-  /** The path string to render as an SVG. Mutually exclusive with `component` prop */
+  /** The path string to render as an SVG. Mutually exclusive with `component`
+   * prop */
   path?: never;
 };
 
@@ -13,8 +14,9 @@ type PathProps = {
 };
 
 /**
- * By using a union type of ComponentProps and PathProps, we can ensure that either `component` or `path`
- * is passed in, but not both, as they are mutually exclusive.
+ * By using a union type of ComponentProps and PathProps, we can ensure that
+ * either `component` or `path` is passed in, but not both, as they are mutually
+ * exclusive.
  *
  * @example
  * // Valid
@@ -31,13 +33,15 @@ type ExclusiveProps = ComponentProps | PathProps;
 type RadiusIconExtendedProps = {
   /** Icon size. Will automatically set the `width` and `height` of the SVG */
   size: CSSProp<'sizing', 'semantic' | 'component'>;
-  /** Icon fill color. Defaults to `currentColor` so that the icon will inherit the color of the parent element */
+  /** Icon fill color. Defaults to `currentColor` so that the icon will inherit
+   * the color of the parent element */
   fill?: CSSProp<'color', 'component'>;
   /** Custom class name to override styling if needed */
   className?: string;
 } & ExclusiveProps;
 
-/** The props to omit from the native svg tag (since we have our own implementations) */
+/** The props to omit from the native svg tag (since we have our own
+ * implementations) */
 type PropsToOmit = keyof RadiusIconExtendedProps;
 
 /** The native react SVG attributes accepted as props */

--- a/library/core-components/utils/flatten.utils.ts
+++ b/library/core-components/utils/flatten.utils.ts
@@ -1,0 +1,33 @@
+type Primitive = string | number | boolean | symbol | null | undefined;
+
+type NestedObject<T extends Primitive> = {
+  [key: string]: T | NestedObject<T>;
+};
+
+/** type guard to assert that variable is an object */
+const isObject = (obj: unknown): obj is Record<string, unknown> =>
+  typeof obj === 'object' && obj !== null;
+
+/** Type guard to assert that variable is NestedObject */
+const isNestedObject = <T extends Primitive>(
+  obj: unknown
+): obj is NestedObject<T> => isObject(obj);
+
+/** Flattens an object into an array of values. */
+export const flattenObject = <T extends Primitive>(obj: NestedObject<T>) => {
+  const result: T[] = [];
+
+  function traverse(o: NestedObject<T>) {
+    for (const key in o) {
+      const value = o[key];
+      if (isNestedObject<T>(value)) {
+        traverse(value);
+      } else {
+        result.push(value);
+      }
+    }
+  }
+
+  traverse(obj);
+  return result;
+};

--- a/library/core-components/utils/utils.test.ts
+++ b/library/core-components/utils/utils.test.ts
@@ -1,4 +1,5 @@
 import { renderCSSProp } from './design-tokens.utils';
+import { flattenObject } from './flatten.utils';
 
 describe('utils', () => {
   describe('design-tokens.utils', () => {
@@ -14,6 +15,23 @@ describe('utils', () => {
             css: '1px solid red',
           })
         ).toBe('1px solid red');
+      });
+    });
+  });
+
+  describe('flatten.utils', () => {
+    describe('flattenObject', () => {
+      it('should flatten an object into an array', () => {
+        const obj = {
+          a: 1,
+          b: {
+            c: 2,
+            d: {
+              e: 3,
+            },
+          },
+        };
+        expect(flattenObject(obj)).toEqual([1, 2, 3]);
       });
     });
   });

--- a/library/foundations/package.json
+++ b/library/foundations/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "test": "jest",
     "tokens:ci": "RADIUS_LAYERS_SUFFIX=-${npm_package_version} yarn tokens:validate",
-    "tokens:update": "export RADIUS_LAYERS_SUFFIX=-${npm_package_version} && yarn tokens:validate && yarn tokens:parse && yarn tokens:generate && yarn tokens:docs && yarn tokens:types",
+    "tokens:update": "export RADIUS_LAYERS_SUFFIX=-${npm_package_version} && yarn tokens:validate && yarn tokens:parse && yarn tokens:generate && yarn tokens:docs && yarn tokens:constants && yarn tokens:types",
     "tokens:parse": "mkdir -p generated && cat ./tokens.json | ts-node scripts/to-layers.ts > generated/token-layers${RADIUS_LAYERS_SUFFIX}.json",
     "tokens:validate": "cat ./tokens.json | ts-node scripts/validate-layers.ts generated/token-layers${RADIUS_LAYERS_SUFFIX}.json",
     "tokens:generate": "cat generated/token-layers${RADIUS_LAYERS_SUFFIX}.json | ts-node scripts/generate-theme.ts css > generated/theme.css",


### PR DESCRIPTION
Icon changes:
- now uses token for size
- now uses generated token object structure instead of strings
  - allows us to populate storybook controls automatically