### PR TITLE
Typography token integration

### DIFF
--- a/library/core-components/components/text-and-image/text-and-image.tsx
+++ b/library/core-components/components/text-and-image/text-and-image.tsx
@@ -41,7 +41,7 @@ export const TextAndImage = forwardRef<React.ElementType, TextAndImageProps>(
             // @ts-expect-error - this component needs refactor with new tokens
             font="--typography-heading-lg"
             // @ts-expect-error - this component needs refactor with new tokens
-            color="--color-text-on-base-primary"
+            fill="--color-text-on-base-primary"
           >
             {title}
           </Typography>
@@ -50,7 +50,7 @@ export const TextAndImage = forwardRef<React.ElementType, TextAndImageProps>(
             // @ts-expect-error - this component needs refactor with new tokens
             font="--typography-body-md"
             // @ts-expect-error - this component needs refactor with new tokens
-            color="--color-text-on-base-secondary"
+            fill="--color-text-on-base-secondary"
           >
             {body}
           </Typography>

--- a/library/core-components/components/typography/__tests__/typography.test.tsx
+++ b/library/core-components/components/typography/__tests__/typography.test.tsx
@@ -28,20 +28,6 @@ describe('<Typography />', () => {
     expect(getByText('Hello World')).toHaveStyle('text-align: left');
   });
 
-  test('should have medium body font by default', () => {
-    const { getByText } = render(<Typography>Hello World</Typography>);
-    expect(getByText('Hello World')).toHaveStyle(
-      'font: var(--typography-body-md)'
-    );
-  });
-
-  test('should have primary text color by default', () => {
-    const { getByText } = render(<Typography>Hello World</Typography>);
-    expect(getByText('Hello World')).toHaveStyle(
-      'color: var(--color-text-on-base-primary)'
-    );
-  });
-
   test('should have no accessibility violations', async () => {
     const { getByText } = render(<Typography>Hello World</Typography>);
     expect(await axe(getByText('Hello World'))).toHaveNoViolations();

--- a/library/core-components/components/typography/typography.stories.tsx
+++ b/library/core-components/components/typography/typography.stories.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
 import { Meta, StoryObj, ArgTypes, Args } from '@storybook/react';
+import { radiusTokens } from '@rangle/radius-foundations/generated/design-tokens.constants';
 // import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Typography } from './typography';
+import { flattenObject } from '../../utils';
 
 const meta: Meta<typeof Typography> = {
   component: Typography,
@@ -24,95 +25,50 @@ const meta: Meta<typeof Typography> = {
     align: {
       defaultValue: 'left',
     },
-    color: {
-      defaultValue: '--color-text-on-base-primary',
-      options: [
-        '--color-text-on-base-primary',
-        '--color-text-on-base-secondary',
-        '--color-text-on-base-accent',
-        '--color-text-on-base-disabled',
-        '--color-text-inverse-primary',
-        '--color-text-inverse-secondary',
-        '--color-text-inverse-accent',
-        '--color-text-on-subtle-primary',
-        '--color-text-on-subtle-secondary',
-        '--color-text-on-subtle-accent',
-        '--color-text-on-subtle-disabled',
-        '--color-text-on-accent-primary',
-        '--color-text-on-accent-secondary',
-        '--color-text-on-accent-disabled',
-        '--color-text-primary-action-default',
-        '--color-text-primary-action-hover',
-        '--color-text-primary-action-active',
-        '--color-text-primary-action-focus',
-        '--color-text-primary-action-disabled',
-        '--color-text-secondary-action-default',
-        '--color-text-secondary-action-hover',
-        '--color-text-secondary-action-active',
-        '--color-text-secondary-action-focus',
-        '--color-text-secondary-action-disabled',
-        '--color-text-tertiary-action-default',
-        '--color-text-tertiary-action-hover',
-        '--color-text-tertiary-action-active',
-        '--color-text-tertiary-action-focus',
-        '--color-text-tertiary-action-disabled',
-      ],
-      control: 'select',
+    fill: {
+      options: flattenObject(radiusTokens.component.color),
     },
     font: {
-      defaultValue: '--typography-body-md',
-      options: [
-        '--typography-heading-xxl',
-        '--typography-heading-xl',
-        '--typography-heading-lg',
-        '--typography-heading-md',
-        '--typography-heading-sm',
-        '--typography-heading-xs',
-        '--typography-body-xl',
-        '--typography-body-md',
-        '--typography-body-sm',
-        '--typography-link-sm',
-        '--typography-btn-lg',
-        '--typography-btn-md',
-        '--typography-btn-sm',
-      ],
-      control: 'select',
+      options: flattenObject({
+        core: radiusTokens.core.typography,
+        semantic: radiusTokens.semantic.typography,
+        component: radiusTokens.component.typography,
+      }),
     },
   } as ArgTypes, // TODO: Fix argTypes inference (broken due to polymorphic implementation?). This assertion is a workaround.
   args: {
     children: 'Hello World!',
     as: 'p',
     align: 'left',
-    color: '--color-text-on-base-primary',
-    font: '--typography-body-md',
+    font: radiusTokens.core.typography.desktop.body.md,
   } as Args, // TODO: Fix args inference (broken due to polymorphic implementation?). This assertion is a workaround.
 };
 
 export default meta;
 type Story = StoryObj<typeof Typography>;
 
-export const Basic: Story = {};
+export const Default: Story = {};
 
-export const Example: Story = {
-  render: () => (
-    <div>
-      <Typography font="--typography-heading-xl">Title</Typography>
-      <Typography color="--color-text-on-base-accent">
-        Some body text. Lorem ipsum dolor sit, amet consectetur adipisicing
-        elit. Fuga, blanditiis.
-      </Typography>
-      <Typography
-        font="--typography-body-sm"
-        color="--color-text-on-base-secondary"
-        align="right"
-      >
-        *Footnote
-      </Typography>
-    </div>
-  ),
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
-};
+// export const Example: Story = {
+//   render: () => (
+//     <div>
+//       <Typography font={radiusTokens.semantic.typography.desktop.}>Title</Typography>
+//       <Typography fill="--color-text-on-base-accent">
+//         Some body text. Lorem ipsum dolor sit, amet consectetur adipisicing
+//         elit. Fuga, blanditiis.
+//       </Typography>
+//       <Typography
+//         font="--typography-body-sm"
+//         fill="--color-text-on-base-secondary"
+//         align="right"
+//       >
+//         *Footnote
+//       </Typography>
+//     </div>
+//   ),
+//   parameters: {
+//     controls: {
+//       disable: true,
+//     },
+//   },
+// };

--- a/library/core-components/components/typography/typography.stories.tsx
+++ b/library/core-components/components/typography/typography.stories.tsx
@@ -35,12 +35,31 @@ const meta: Meta<typeof Typography> = {
         component: radiusTokens.component.typography,
       }),
     },
+    fontFamily: {
+      options: flattenObject(radiusTokens.core.fontFamilies),
+    },
+    lineHeight: {
+      options: flattenObject(radiusTokens.core.lineHeights),
+    },
+    fontWeight: {
+      options: flattenObject(radiusTokens.core.fontWeights),
+    },
+    fontSize: {
+      options: flattenObject(radiusTokens.core.fontSize),
+    },
+    letterSpacing: {
+      options: flattenObject(radiusTokens.core.letterSpacing),
+    },
+    textDecoration: {
+      options: flattenObject(radiusTokens.core.textDecoration),
+    },
   } as ArgTypes, // TODO: Fix argTypes inference (broken due to polymorphic implementation?). This assertion is a workaround.
   args: {
     children: 'Hello World!',
     as: 'p',
     align: 'left',
     font: radiusTokens.core.typography.desktop.body.md,
+    fill: radiusTokens.component.color.button.secondary.default.label,
   } as Args, // TODO: Fix args inference (broken due to polymorphic implementation?). This assertion is a workaround.
 };
 
@@ -48,27 +67,3 @@ export default meta;
 type Story = StoryObj<typeof Typography>;
 
 export const Default: Story = {};
-
-// export const Example: Story = {
-//   render: () => (
-//     <div>
-//       <Typography font={radiusTokens.semantic.typography.desktop.}>Title</Typography>
-//       <Typography fill="--color-text-on-base-accent">
-//         Some body text. Lorem ipsum dolor sit, amet consectetur adipisicing
-//         elit. Fuga, blanditiis.
-//       </Typography>
-//       <Typography
-//         font="--typography-body-sm"
-//         fill="--color-text-on-base-secondary"
-//         align="right"
-//       >
-//         *Footnote
-//       </Typography>
-//     </div>
-//   ),
-//   parameters: {
-//     controls: {
-//       disable: true,
-//     },
-//   },
-// };

--- a/library/core-components/components/typography/typography.styles.ts
+++ b/library/core-components/components/typography/typography.styles.ts
@@ -1,25 +1,39 @@
-import { css } from '@emotion/css';
-import { renderCSSProp } from '../../utils/design-tokens.utils';
-import { TypographyExtendedProps } from './typography';
+import { renderCSSProp, createUseStyles } from '../../utils';
+import { TypographyExtendedProps } from './typography.types';
 
 export type StylesProps = Pick<
   TypographyExtendedProps,
-  'align' | 'color' | 'font'
+  | 'align'
+  | 'fill'
+  | 'font'
+  | 'fontFamily'
+  | 'lineHeight'
+  | 'fontSize'
+  | 'fontWeight'
+  | 'letterSpacing'
+  | 'textDecoration'
 >;
 
-export const getStyles = ({
+export const useStyles = ({
   align = 'left',
-  // NOTE: this component should not have default values for color and font as they should always come from the component layer or be inherited from the parent
-  // @ts-expect-error - this component needs refactor with new tokens
-  color = '--color-text-on-base-primary',
-  // @ts-expect-error - this component needs refactor with new tokens
-  font = '--typography-body-md',
-}: StylesProps) => {
-  return css`
-    color: ${renderCSSProp(color)};
+  fill,
+  font,
+  fontFamily,
+  lineHeight,
+  fontSize,
+  fontWeight,
+  letterSpacing,
+  textDecoration,
+}: StylesProps) => createUseStyles`
+    color: ${renderCSSProp(fill)};
     text-align: ${align};
     font: ${renderCSSProp(font)};
+    font-family: ${renderCSSProp(fontFamily)};
+    line-height: ${renderCSSProp(lineHeight)};
+    font-size: ${renderCSSProp(fontSize)};
+    font-weight: ${renderCSSProp(fontWeight)};
+    letter-spacing: ${renderCSSProp(letterSpacing)};
+    text-decoration: ${renderCSSProp(textDecoration)};
     margin: 0;
     padding: 0;
-  `;
-};
+`;

--- a/library/core-components/components/typography/typography.tsx
+++ b/library/core-components/components/typography/typography.tsx
@@ -1,45 +1,10 @@
-import React, { useMemo, forwardRef } from 'react';
+import React, { forwardRef } from 'react';
 import { cx } from '@emotion/css';
-import { CSSProp } from '@rangle/radius-foundations/generated/design-tokens.types';
 
-import { PolymorphicComponentPropWithRef } from '../../utils/polymorphic.types';
 import { elementAndProps } from '../../utils/polymorphic.utils';
 
-import { getStyles } from './typography.styles';
-
-export type Alignment = 'left' | 'center' | 'right';
-
-// TODO - fix polymorphic types (type errors due to different expected props for some tags)
-export type TypographyTag =
-  | 'h1'
-  | 'h2'
-  | 'h3'
-  | 'h4'
-  | 'h5'
-  | 'h6'
-  | 'p'
-  | 'div';
-// | 'span'
-// | 'a'
-// | 'article'
-// | 'section'
-// | 'em'
-// | 'strong';
-
-export type TypographyExtendedProps = {
-  /** Text alignment */
-  align?: Alignment;
-  /** Text color */
-  color?: CSSProp<'color'>;
-  /** Font (css shorthand property - see https://developer.mozilla.org/en-US/docs/Web/CSS/font) */
-  font?: CSSProp<'typography'>;
-  children: React.ReactNode;
-};
-
-export type TypographyProps = PolymorphicComponentPropWithRef<
-  TypographyTag,
-  TypographyExtendedProps
->;
+import { useStyles } from './typography.styles';
+import { TypographyProps, TypographyTag } from './typography.types';
 
 /** # Typography Component
  * A polymorphic component that represents a text element.
@@ -47,22 +12,40 @@ export type TypographyProps = PolymorphicComponentPropWithRef<
  * declared in the Specific Props type above.
  */
 export const Typography = forwardRef<TypographyTag, TypographyProps>(
-  ({ align, color, font, children, className, ...rest }, ref) => {
+  (
+    {
+      align,
+      fill,
+      font,
+      fontFamily,
+      lineHeight,
+      fontWeight,
+      fontSize,
+      letterSpacing,
+      textDecoration,
+      children,
+      className,
+      ...rest
+    },
+    ref
+  ) => {
     const element = elementAndProps(rest, ref, 'p');
 
-    const style = useMemo(
-      () =>
-        getStyles({
-          align,
-          color,
-          font,
-        }),
-      [align, color, font]
-    );
+    const styles = useStyles({
+      align,
+      fill,
+      font,
+      fontFamily,
+      lineHeight,
+      fontWeight,
+      fontSize,
+      letterSpacing,
+      textDecoration,
+    });
 
     return (
       <element.Component
-        className={cx(style, className)}
+        className={cx(styles, className)}
         ref={element.props.ref}
         {...element.props}
       >

--- a/library/core-components/components/typography/typography.types.ts
+++ b/library/core-components/components/typography/typography.types.ts
@@ -1,0 +1,42 @@
+import { CSSProp } from '@rangle/radius-foundations/generated/design-tokens.types';
+import { PolymorphicComponentPropWithRef } from '../../utils/polymorphic.types';
+
+export type Alignment = 'left' | 'center' | 'right';
+
+// TODO - fix polymorphic types (type errors due to different expected props for some tags)
+export type TypographyTag =
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'p'
+  | 'div';
+// | 'span'
+// | 'a'
+// | 'article'
+// | 'section'
+// | 'em'
+// | 'strong';
+
+export type TypographyExtendedProps = {
+  /** Text alignment */
+  align?: Alignment;
+  /** Text color */
+  fill?: CSSProp<'color'>;
+  /** Font (css shorthand property - see https://developer.mozilla.org/en-US/docs/Web/CSS/font) */
+  font?: CSSProp<'typography'>;
+  fontFamily?: CSSProp<'fontFamilies'>;
+  lineHeight?: CSSProp<'lineHeights'>;
+  fontWeight?: CSSProp<'fontWeights'>;
+  fontSize?: CSSProp<'fontSizes'>;
+  letterSpacing?: CSSProp<'letterSpacing'>;
+  textDecoration?: CSSProp<'textDecoration'>;
+  children: React.ReactNode;
+};
+
+export type TypographyProps = PolymorphicComponentPropWithRef<
+  TypographyTag,
+  TypographyExtendedProps
+>;

--- a/library/core-components/components/typography/typography.types.ts
+++ b/library/core-components/components/typography/typography.types.ts
@@ -21,18 +21,25 @@ export type TypographyTag =
 // | 'strong';
 
 export type TypographyExtendedProps = {
-  /** Text alignment */
-  align?: Alignment;
   /** Text color */
   fill?: CSSProp<'color'>;
+  /** Text alignment (corresponds to `text-align` style) */
+  align?: Alignment;
   /** Font (css shorthand property - see https://developer.mozilla.org/en-US/docs/Web/CSS/font) */
   font?: CSSProp<'typography'>;
+  /** Font Family - will override `font-family` style of the `font` prop */
   fontFamily?: CSSProp<'fontFamilies'>;
+  /** Line Height - will override `line-height` style of the `font` prop */
   lineHeight?: CSSProp<'lineHeights'>;
+  /** Font Weight - will override `font-weight` style of the `font` prop */
   fontWeight?: CSSProp<'fontWeights'>;
+  /** Font Size - will override `font-size` style of the `font` prop */
   fontSize?: CSSProp<'fontSizes'>;
+  /** Letter Spacing - will override `letter-spacing` style of the `font` prop */
   letterSpacing?: CSSProp<'letterSpacing'>;
+  /** Text Decoration - will override `text-decoration` style of the `font` prop */
   textDecoration?: CSSProp<'textDecoration'>;
+  /** The content of the Typography component */
   children: React.ReactNode;
 };
 

--- a/library/core-components/utils/index.ts
+++ b/library/core-components/utils/index.ts
@@ -1,0 +1,5 @@
+export * from './design-tokens.utils';
+export * from './flatten.utils';
+export * from './polymorphic.utils';
+export * from './polymorphic.types';
+export * from './styles.utils';

--- a/library/foundations/generated/token-layers-2.0.3.json
+++ b/library/foundations/generated/token-layers-2.0.3.json
@@ -1,0 +1,2521 @@
+{
+  "layers": [
+    {
+      "name": "core",
+      "isStatic": true,
+      "variables": [
+        {
+          "key": "--color-core-color-red-50",
+          "name": "core.color.red.50",
+          "value": "#FDE7E2",
+          "type": "color",
+          "rawValue": "#FDE7E2"
+        },
+        {
+          "key": "--color-core-color-red-100",
+          "name": "core.color.red.100",
+          "value": "#FFCBC0",
+          "type": "color",
+          "rawValue": "#FFCBC0"
+        },
+        {
+          "key": "--color-core-color-red-200",
+          "name": "core.color.red.200",
+          "value": "#F7856E",
+          "type": "color",
+          "rawValue": "#F7856E"
+        },
+        {
+          "key": "--color-core-color-red-300",
+          "name": "core.color.red.300",
+          "value": "#F67055",
+          "type": "color",
+          "rawValue": "#F67055"
+        },
+        {
+          "key": "--color-core-color-red-400",
+          "name": "core.color.red.400",
+          "value": "#F65836",
+          "type": "color",
+          "rawValue": "#F65836"
+        },
+        {
+          "key": "--color-core-color-red-500",
+          "name": "core.color.red.500",
+          "value": "#D44527",
+          "type": "color",
+          "rawValue": "#D44527"
+        },
+        {
+          "key": "--color-core-color-red-600",
+          "name": "core.color.red.600",
+          "value": "#A3331A",
+          "type": "color",
+          "rawValue": "#A3331A"
+        },
+        {
+          "key": "--color-core-color-red-700",
+          "name": "core.color.red.700",
+          "value": "#772513",
+          "type": "color",
+          "rawValue": "#772513"
+        },
+        {
+          "key": "--color-core-color-red-800",
+          "name": "core.color.red.800",
+          "value": "#581C0E",
+          "type": "color",
+          "rawValue": "#581C0E"
+        },
+        {
+          "key": "--color-core-color-red-900",
+          "name": "core.color.red.900",
+          "value": "#351008",
+          "type": "color",
+          "rawValue": "#351008"
+        },
+        {
+          "key": "--color-core-color-neutral-50",
+          "name": "core.color.neutral.50",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "#FFFFFF"
+        },
+        {
+          "key": "--color-core-color-neutral-100",
+          "name": "core.color.neutral.100",
+          "value": "#FAFAFA",
+          "type": "color",
+          "rawValue": "#FAFAFA"
+        },
+        {
+          "key": "--color-core-color-neutral-200",
+          "name": "core.color.neutral.200",
+          "value": "#F1F3F4",
+          "type": "color",
+          "rawValue": "#F1F3F4"
+        },
+        {
+          "key": "--color-core-color-neutral-300",
+          "name": "core.color.neutral.300",
+          "value": "#EDEDED",
+          "type": "color",
+          "rawValue": "#EDEDED"
+        },
+        {
+          "key": "--color-core-color-neutral-400",
+          "name": "core.color.neutral.400",
+          "value": "#D9D9D9",
+          "type": "color",
+          "rawValue": "#D9D9D9"
+        },
+        {
+          "key": "--color-core-color-neutral-500",
+          "name": "core.color.neutral.500",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "#CCCCCC"
+        },
+        {
+          "key": "--color-core-color-neutral-600",
+          "name": "core.color.neutral.600",
+          "value": "#A6A6A6",
+          "type": "color",
+          "rawValue": "#A6A6A6"
+        },
+        {
+          "key": "--color-core-color-neutral-700",
+          "name": "core.color.neutral.700",
+          "value": "#656565",
+          "type": "color",
+          "rawValue": "#656565"
+        },
+        {
+          "key": "--color-core-color-neutral-800",
+          "name": "core.color.neutral.800",
+          "value": "#4D4D4D",
+          "type": "color",
+          "rawValue": "#4D4D4D"
+        },
+        {
+          "key": "--color-core-color-neutral-900",
+          "name": "core.color.neutral.900",
+          "value": "#262626",
+          "type": "color",
+          "rawValue": "#262626"
+        },
+        {
+          "key": "--color-core-color-green-50",
+          "name": "core.color.green.50",
+          "value": "#D9E2CC",
+          "type": "color",
+          "rawValue": "#D9E2CC"
+        },
+        {
+          "key": "--color-core-color-green-100",
+          "name": "core.color.green.100",
+          "value": "#B2CBA3",
+          "type": "color",
+          "rawValue": "#B2CBA3"
+        },
+        {
+          "key": "--color-core-color-green-200",
+          "name": "core.color.green.200",
+          "value": "#82B37A",
+          "type": "color",
+          "rawValue": "#82B37A"
+        },
+        {
+          "key": "--color-core-color-green-300",
+          "name": "core.color.green.300",
+          "value": "#529A55",
+          "type": "color",
+          "rawValue": "#529A55"
+        },
+        {
+          "key": "--color-core-color-green-400",
+          "name": "core.color.green.400",
+          "value": "#2A8042",
+          "type": "color",
+          "rawValue": "#2A8042"
+        },
+        {
+          "key": "--color-core-color-green-500",
+          "name": "core.color.green.500",
+          "value": "#036635",
+          "type": "color",
+          "rawValue": "#036635"
+        },
+        {
+          "key": "--color-core-color-green-600",
+          "name": "core.color.green.600",
+          "value": "#015B2E",
+          "type": "color",
+          "rawValue": "#015B2E"
+        },
+        {
+          "key": "--color-core-color-green-700",
+          "name": "core.color.green.700",
+          "value": "#004F28",
+          "type": "color",
+          "rawValue": "#004F28"
+        },
+        {
+          "key": "--color-core-color-green-800",
+          "name": "core.color.green.800",
+          "value": "#004321",
+          "type": "color",
+          "rawValue": "#004321"
+        },
+        {
+          "key": "--color-core-color-green-900",
+          "name": "core.color.green.900",
+          "value": "#00371B",
+          "type": "color",
+          "rawValue": "#00371B"
+        },
+        {
+          "key": "--color-core-color-orange-50",
+          "name": "core.color.orange.50",
+          "value": "#FFEF8C",
+          "type": "color",
+          "rawValue": "#FFEF8C"
+        },
+        {
+          "key": "--color-core-color-orange-100",
+          "name": "core.color.orange.100",
+          "value": "#FFDF70",
+          "type": "color",
+          "rawValue": "#FFDF70"
+        },
+        {
+          "key": "--color-core-color-orange-200",
+          "name": "core.color.orange.200",
+          "value": "#FFCD54",
+          "type": "color",
+          "rawValue": "#FFCD54"
+        },
+        {
+          "key": "--color-core-color-orange-300",
+          "name": "core.color.orange.300",
+          "value": "#FFB738",
+          "type": "color",
+          "rawValue": "#FFB738"
+        },
+        {
+          "key": "--color-core-color-orange-400",
+          "name": "core.color.orange.400",
+          "value": "#FF9E1C",
+          "type": "color",
+          "rawValue": "#FF9E1C"
+        },
+        {
+          "key": "--color-core-color-orange-500",
+          "name": "core.color.orange.500",
+          "value": "#FF8300",
+          "type": "color",
+          "rawValue": "#FF8300"
+        },
+        {
+          "key": "--color-core-color-orange-600",
+          "name": "core.color.orange.600",
+          "value": "#DF7300",
+          "type": "color",
+          "rawValue": "#DF7300"
+        },
+        {
+          "key": "--color-core-color-orange-700",
+          "name": "core.color.orange.700",
+          "value": "#BF6200",
+          "type": "color",
+          "rawValue": "#BF6200"
+        },
+        {
+          "key": "--color-core-color-orange-800",
+          "name": "core.color.orange.800",
+          "value": "#9F5200",
+          "type": "color",
+          "rawValue": "#9F5200"
+        },
+        {
+          "key": "--color-core-color-orange-900",
+          "name": "core.color.orange.900",
+          "value": "#804200",
+          "type": "color",
+          "rawValue": "#804200"
+        },
+        {
+          "key": "--color-core-color-blue-50",
+          "name": "core.color.blue.50",
+          "value": "#BFD9FF",
+          "type": "color",
+          "rawValue": "#BFD9FF"
+        },
+        {
+          "key": "--color-core-color-blue-100",
+          "name": "core.color.blue.100",
+          "value": "#99C8FF",
+          "type": "color",
+          "rawValue": "#99C8FF"
+        },
+        {
+          "key": "--color-core-color-blue-200",
+          "name": "core.color.blue.200",
+          "value": "#73BCFE",
+          "type": "color",
+          "rawValue": "#73BCFE"
+        },
+        {
+          "key": "--color-core-color-blue-300",
+          "name": "core.color.blue.300",
+          "value": "#4DB4FA",
+          "type": "color",
+          "rawValue": "#4DB4FA"
+        },
+        {
+          "key": "--color-core-color-blue-400",
+          "name": "core.color.blue.400",
+          "value": "#26AEF5",
+          "type": "color",
+          "rawValue": "#26AEF5"
+        },
+        {
+          "key": "--color-core-color-blue-500",
+          "name": "core.color.blue.500",
+          "value": "#00ACEE",
+          "type": "color",
+          "rawValue": "#00ACEE"
+        },
+        {
+          "key": "--color-core-color-blue-600",
+          "name": "core.color.blue.600",
+          "value": "#0097D0",
+          "type": "color",
+          "rawValue": "#0097D0"
+        },
+        {
+          "key": "--color-core-color-blue-700",
+          "name": "core.color.blue.700",
+          "value": "#0081B3",
+          "type": "color",
+          "rawValue": "#0081B3"
+        },
+        {
+          "key": "--color-core-color-blue-800",
+          "name": "core.color.blue.800",
+          "value": "#006C95",
+          "type": "color",
+          "rawValue": "#006C95"
+        },
+        {
+          "key": "--color-core-color-blue-900",
+          "name": "core.color.blue.900",
+          "value": "#005677",
+          "type": "color",
+          "rawValue": "#005677"
+        },
+        {
+          "key": "--color-core-color-none",
+          "name": "core.color.none",
+          "value": "rgba(0,0,0,0)",
+          "type": "color",
+          "rawValue": "rgba(0,0,0,0)"
+        },
+        {
+          "key": "--borderRadius-core-border-radius-2",
+          "name": "core.borderRadius.2",
+          "value": "2px",
+          "type": "borderRadius",
+          "rawValue": "2px"
+        },
+        {
+          "key": "--borderRadius-core-border-radius-4",
+          "name": "core.borderRadius.4",
+          "value": "4px",
+          "type": "borderRadius",
+          "rawValue": "4px"
+        },
+        {
+          "key": "--borderRadius-core-border-radius-8",
+          "name": "core.borderRadius.8",
+          "value": "8px",
+          "type": "borderRadius",
+          "rawValue": "8px"
+        },
+        {
+          "key": "--borderRadius-core-border-radius-16",
+          "name": "core.borderRadius.16",
+          "value": "16px",
+          "type": "borderRadius",
+          "rawValue": "16px"
+        },
+        {
+          "key": "--borderRadius-core-border-radius-24",
+          "name": "core.borderRadius.24",
+          "value": "24px",
+          "type": "borderRadius",
+          "rawValue": "24px"
+        },
+        {
+          "key": "--borderRadius-core-border-radius-32",
+          "name": "core.borderRadius.32",
+          "value": "32px",
+          "type": "borderRadius",
+          "rawValue": "32px"
+        },
+        {
+          "key": "--borderRadius-core-border-radius-36",
+          "name": "core.borderRadius.36",
+          "value": "36px",
+          "type": "borderRadius",
+          "rawValue": "36px"
+        },
+        {
+          "key": "--borderRadius-core-border-radius-none",
+          "name": "core.borderRadius.none",
+          "value": "0px",
+          "type": "borderRadius",
+          "rawValue": "0px"
+        },
+        {
+          "key": "--borderRadius-core-border-radius-max",
+          "name": "core.borderRadius.max",
+          "value": "300px",
+          "type": "borderRadius",
+          "rawValue": "300px"
+        },
+        {
+          "key": "--boxShadow-core-shadow-0",
+          "name": "core.shadow.0",
+          "value": "0 0 0 0 #000000",
+          "type": "boxShadow",
+          "rawValue": "0 0 0 0 #000000"
+        },
+        {
+          "key": "--boxShadow-core-shadow-50",
+          "name": "core.shadow.50",
+          "value": "0 1 3 0 rgba(38,38,38,0.1),0 0 1 0 rgba(38,38,38,0.1)",
+          "type": "boxShadow",
+          "rawValue": "0 1 3 0 rgba(38,38,38,0.1),0 0 1 0 rgba(38,38,38,0.1)"
+        },
+        {
+          "key": "--boxShadow-core-shadow-100",
+          "name": "core.shadow.100",
+          "value": "0 2 4 0 rgba(38,38,38,0.1),0 0 1 0 rgba(38,38,38,0.1)",
+          "type": "boxShadow",
+          "rawValue": "0 2 4 0 rgba(38,38,38,0.1),0 0 1 0 rgba(38,38,38,0.1)"
+        },
+        {
+          "key": "--boxShadow-core-shadow-200",
+          "name": "core.shadow.200",
+          "value": "0 4 8 0 rgba(38,38,38,0.1),0 0 1 0 rgba(38,38,38,0.1)",
+          "type": "boxShadow",
+          "rawValue": "0 4 8 0 rgba(38,38,38,0.1),0 0 1 0 rgba(38,38,38,0.1)"
+        },
+        {
+          "key": "--boxShadow-core-shadow-300",
+          "name": "core.shadow.300",
+          "value": "0 8 16 0 rgba(38,38,38,0.1),0 0 1 0 rgba(38,38,38,0.1)",
+          "type": "boxShadow",
+          "rawValue": "0 8 16 0 rgba(38,38,38,0.1),0 0 1 0 rgba(38,38,38,0.1)"
+        },
+        {
+          "key": "--boxShadow-core-shadow-400",
+          "name": "core.shadow.400",
+          "value": "0 16 24 0 rgba(38,38,38,0.1),0 0 1 0 rgba(38,38,38,0.1)",
+          "type": "boxShadow",
+          "rawValue": "0 16 24 0 rgba(38,38,38,0.1),0 0 1 0 rgba(38,38,38,0.1)"
+        },
+        {
+          "key": "--opacity-core-opacity-25percent",
+          "name": "core.opacity.25percent",
+          "value": "25%",
+          "type": "opacity",
+          "rawValue": "25%"
+        },
+        {
+          "key": "--opacity-core-opacity-35percent",
+          "name": "core.opacity.35percent",
+          "value": "35%",
+          "type": "opacity",
+          "rawValue": "35%"
+        },
+        {
+          "key": "--opacity-core-opacity-65percent",
+          "name": "core.opacity.65percent",
+          "value": "65%",
+          "type": "opacity",
+          "rawValue": "65%"
+        },
+        {
+          "key": "--opacity-core-opacity-90percent",
+          "name": "core.opacity.90percent",
+          "value": "90%",
+          "type": "opacity",
+          "rawValue": "90%"
+        },
+        {
+          "key": "--fontFamilies-core-font-families-riforma-ll",
+          "name": "core.fontFamilies.riforma-ll",
+          "value": "Riforma LL",
+          "type": "fontFamilies",
+          "rawValue": "Riforma LL"
+        },
+        {
+          "key": "--lineHeights-core-line-heights-100percent",
+          "name": "core.lineHeights.100percent",
+          "value": "100%",
+          "type": "lineHeights",
+          "rawValue": "100%"
+        },
+        {
+          "key": "--lineHeights-core-line-heights-150percent",
+          "name": "core.lineHeights.150percent",
+          "value": "150%",
+          "type": "lineHeights",
+          "rawValue": "150%"
+        },
+        {
+          "key": "--fontWeights-core-font-weights-light",
+          "name": "core.fontWeights.light",
+          "value": "Light",
+          "type": "fontWeights",
+          "rawValue": "Light"
+        },
+        {
+          "key": "--fontWeights-core-font-weights-regular",
+          "name": "core.fontWeights.regular",
+          "value": "Regular",
+          "type": "fontWeights",
+          "rawValue": "Regular"
+        },
+        {
+          "key": "--fontWeights-core-font-weights-medium",
+          "name": "core.fontWeights.medium",
+          "value": "Medium",
+          "type": "fontWeights",
+          "rawValue": "Medium"
+        },
+        {
+          "key": "--fontWeights-core-font-weights-bold",
+          "name": "core.fontWeights.bold",
+          "value": "Bold",
+          "type": "fontWeights",
+          "rawValue": "Bold"
+        },
+        {
+          "key": "--fontSizes-core-font-size-14",
+          "name": "core.fontSize.14",
+          "value": "14px",
+          "type": "fontSizes",
+          "rawValue": "14px"
+        },
+        {
+          "key": "--fontSizes-core-font-size-18",
+          "name": "core.fontSize.18",
+          "value": "18px",
+          "type": "fontSizes",
+          "rawValue": "18px"
+        },
+        {
+          "key": "--fontSizes-core-font-size-20",
+          "name": "core.fontSize.20",
+          "value": "20px",
+          "type": "fontSizes",
+          "rawValue": "20px"
+        },
+        {
+          "key": "--fontSizes-core-font-size-24",
+          "name": "core.fontSize.24",
+          "value": "24px",
+          "type": "fontSizes",
+          "rawValue": "24px"
+        },
+        {
+          "key": "--fontSizes-core-font-size-36",
+          "name": "core.fontSize.36",
+          "value": "36px",
+          "type": "fontSizes",
+          "rawValue": "36px"
+        },
+        {
+          "key": "--fontSizes-core-font-size-40",
+          "name": "core.fontSize.40",
+          "value": "40px",
+          "type": "fontSizes",
+          "rawValue": "40px"
+        },
+        {
+          "key": "--fontSizes-core-font-size-64",
+          "name": "core.fontSize.64",
+          "value": "64px",
+          "type": "fontSizes",
+          "rawValue": "64px"
+        },
+        {
+          "key": "--fontSizes-core-font-size-80",
+          "name": "core.fontSize.80",
+          "value": "80px",
+          "type": "fontSizes",
+          "rawValue": "80px"
+        },
+        {
+          "key": "--fontSizes-core-font-size-16-base",
+          "name": "core.fontSize.16-base",
+          "value": "16px",
+          "type": "fontSizes",
+          "rawValue": "16px"
+        },
+        {
+          "key": "--letterSpacing-core-letter-spacing-neg1percent",
+          "name": "core.letterSpacing.neg1percent",
+          "value": "-1%",
+          "type": "letterSpacing",
+          "rawValue": "-1%"
+        },
+        {
+          "key": "--letterSpacing-core-letter-spacing-none",
+          "name": "core.letterSpacing.none",
+          "value": "0%",
+          "type": "letterSpacing",
+          "rawValue": "0%"
+        },
+        {
+          "key": "--letterSpacing-core-letter-spacing-1percent",
+          "name": "core.letterSpacing.1percent",
+          "value": "1%",
+          "type": "letterSpacing",
+          "rawValue": "1%"
+        },
+        {
+          "key": "--paragraphSpacing-core-paragraph-spacing-0",
+          "name": "core.paragraphSpacing.0",
+          "value": "0",
+          "type": "paragraphSpacing",
+          "rawValue": "0"
+        },
+        {
+          "key": "--textCase-core-text-case-none",
+          "name": "core.textCase.none",
+          "value": "none",
+          "type": "textCase",
+          "rawValue": "none"
+        },
+        {
+          "key": "--textDecoration-core-text-decoration-none",
+          "name": "core.textDecoration.none",
+          "value": "none",
+          "type": "textDecoration",
+          "rawValue": "none"
+        },
+        {
+          "key": "--spacing-core-spacing-0",
+          "name": "core.spacing.0",
+          "value": "0px",
+          "type": "spacing",
+          "rawValue": "0px"
+        },
+        {
+          "key": "--spacing-core-spacing-2",
+          "name": "core.spacing.2",
+          "value": "2px",
+          "type": "spacing",
+          "rawValue": "2px"
+        },
+        {
+          "key": "--spacing-core-spacing-4",
+          "name": "core.spacing.4",
+          "value": "4px",
+          "type": "spacing",
+          "rawValue": "4px"
+        },
+        {
+          "key": "--spacing-core-spacing-8",
+          "name": "core.spacing.8",
+          "value": "8px",
+          "type": "spacing",
+          "rawValue": "8px"
+        },
+        {
+          "key": "--spacing-core-spacing-12",
+          "name": "core.spacing.12",
+          "value": "12px",
+          "type": "spacing",
+          "rawValue": "12px"
+        },
+        {
+          "key": "--spacing-core-spacing-16",
+          "name": "core.spacing.16",
+          "value": "16px",
+          "type": "spacing",
+          "rawValue": "16px"
+        },
+        {
+          "key": "--spacing-core-spacing-20",
+          "name": "core.spacing.20",
+          "value": "20px",
+          "type": "spacing",
+          "rawValue": "20px"
+        },
+        {
+          "key": "--spacing-core-spacing-24",
+          "name": "core.spacing.24",
+          "value": "24px",
+          "type": "spacing",
+          "rawValue": "24px"
+        },
+        {
+          "key": "--spacing-core-spacing-32",
+          "name": "core.spacing.32",
+          "value": "32px",
+          "type": "spacing",
+          "rawValue": "32px"
+        },
+        {
+          "key": "--spacing-core-spacing-40",
+          "name": "core.spacing.40",
+          "value": "40px",
+          "type": "spacing",
+          "rawValue": "40px"
+        },
+        {
+          "key": "--spacing-core-spacing-48",
+          "name": "core.spacing.48",
+          "value": "48px",
+          "type": "spacing",
+          "rawValue": "48px"
+        },
+        {
+          "key": "--spacing-core-spacing-64",
+          "name": "core.spacing.64",
+          "value": "64px",
+          "type": "spacing",
+          "rawValue": "64px"
+        },
+        {
+          "key": "--spacing-core-spacing-72",
+          "name": "core.spacing.72",
+          "value": "72px",
+          "type": "spacing",
+          "rawValue": "72px"
+        },
+        {
+          "key": "--spacing-core-spacing-80",
+          "name": "core.spacing.80",
+          "value": "80px",
+          "type": "spacing",
+          "rawValue": "80px"
+        },
+        {
+          "key": "--spacing-core-spacing-104",
+          "name": "core.spacing.104",
+          "value": "104px",
+          "type": "spacing",
+          "rawValue": "104px"
+        },
+        {
+          "key": "--spacing-core-spacing-180",
+          "name": "core.spacing.180",
+          "value": "180px",
+          "type": "spacing",
+          "rawValue": "180px"
+        },
+        {
+          "key": "--spacing-core-spacing-240",
+          "name": "core.spacing.240",
+          "value": "240px",
+          "type": "spacing",
+          "rawValue": "240px"
+        },
+        {
+          "key": "--typography-core-typography-desktop-heading-xxl",
+          "name": "core.typography.desktop.heading.xxl",
+          "value": "Bold 80px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.bold} {core.fontSize.80}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-desktop-heading-xl",
+          "name": "core.typography.desktop.heading.xl",
+          "value": "Bold 40px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.bold} {core.fontSize.40}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-desktop-heading-lg",
+          "name": "core.typography.desktop.heading.lg",
+          "value": "Bold 36px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.bold} {core.fontSize.36}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-desktop-heading-md",
+          "name": "core.typography.desktop.heading.md",
+          "value": "Regular 24px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.regular} {core.fontSize.24}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-desktop-heading-sm",
+          "name": "core.typography.desktop.heading.sm",
+          "value": "Medium 20px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.medium} {core.fontSize.20}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-desktop-heading-xs",
+          "name": "core.typography.desktop.heading.xs",
+          "value": "Light 14px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.light} {core.fontSize.14}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-desktop-body-xl",
+          "name": "core.typography.desktop.body.xl",
+          "value": "Regular 24px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.regular} {core.fontSize.24}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-desktop-body-md",
+          "name": "core.typography.desktop.body.md",
+          "value": "Regular 18px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.regular} {core.fontSize.18}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-desktop-body-sm",
+          "name": "core.typography.desktop.body.sm",
+          "value": "Bold 16px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.bold} {core.fontSize.16-base}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-desktop-btn-md",
+          "name": "core.typography.desktop.btn.md",
+          "value": "Medium 20px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.medium} {core.fontSize.20}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-desktop-link-md",
+          "name": "core.typography.desktop.link.md",
+          "value": "Medium 14px/100% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.medium} {core.fontSize.14}/{core.lineHeights.100percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-tablet-heading-xxl",
+          "name": "core.typography.tablet.heading.xxl",
+          "value": "Bold 64px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.bold} {core.fontSize.64}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-tablet-heading-xl",
+          "name": "core.typography.tablet.heading.xl",
+          "value": "Bold 40px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.bold} {core.fontSize.40}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-tablet-heading-lg",
+          "name": "core.typography.tablet.heading.lg",
+          "value": "Bold 36px/100% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.bold} {core.fontSize.36}/{core.lineHeights.100percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-tablet-heading-md",
+          "name": "core.typography.tablet.heading.md",
+          "value": "Regular 20px/100% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.regular} {core.fontSize.20}/{core.lineHeights.100percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-tablet-heading-sm",
+          "name": "core.typography.tablet.heading.sm",
+          "value": "Medium 16px/100% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.medium} {core.fontSize.16-base}/{core.lineHeights.100percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-tablet-heading-xs",
+          "name": "core.typography.tablet.heading.xs",
+          "value": "Light 14px/100% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.light} {core.fontSize.14}/{core.lineHeights.100percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-tablet-body-xl",
+          "name": "core.typography.tablet.body.xl",
+          "value": "Regular 20px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.regular} {core.fontSize.20}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-tablet-body-md",
+          "name": "core.typography.tablet.body.md",
+          "value": "Regular 18px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.regular} {core.fontSize.18}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-tablet-body-sm",
+          "name": "core.typography.tablet.body.sm",
+          "value": "Bold 16px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.bold} {core.fontSize.16-base}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-tablet-link-md",
+          "name": "core.typography.tablet.link.md",
+          "value": "Medium 14px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.medium} {core.fontSize.14}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-tablet-btn-md",
+          "name": "core.typography.tablet.btn.md",
+          "value": "Medium 18px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.medium} {core.fontSize.18}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-mobile-heading-xxl",
+          "name": "core.typography.mobile.heading.xxl",
+          "value": "Bold 40px/100% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.bold} {core.fontSize.40}/{core.lineHeights.100percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-mobile-heading-xl",
+          "name": "core.typography.mobile.heading.xl",
+          "value": "Bold 36px/100% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.bold} {core.fontSize.36}/{core.lineHeights.100percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-mobile-heading-lg",
+          "name": "core.typography.mobile.heading.lg",
+          "value": "Bold 24px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.bold} {core.fontSize.24}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-mobile-heading-md",
+          "name": "core.typography.mobile.heading.md",
+          "value": "Regular 20px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.regular} {core.fontSize.20}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-mobile-heading-sm",
+          "name": "core.typography.mobile.heading.sm",
+          "value": "Medium 18px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.medium} {core.fontSize.18}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-mobile-heading-xs",
+          "name": "core.typography.mobile.heading.xs",
+          "value": "Light 14px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.light} {core.fontSize.14}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-mobile-body-xl",
+          "name": "core.typography.mobile.body.xl",
+          "value": "Regular 20px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.regular} {core.fontSize.20}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-mobile-body-md",
+          "name": "core.typography.mobile.body.md",
+          "value": "Regular 18px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.regular} {core.fontSize.18}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-mobile-body-sm",
+          "name": "core.typography.mobile.body.sm",
+          "value": "Bold 16px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.bold} {core.fontSize.16-base}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-mobile-btn-md",
+          "name": "core.typography.mobile.btn.md",
+          "value": "Medium 16px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.medium} {core.fontSize.16-base}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--typography-core-typography-mobile-link-md",
+          "name": "core.typography.mobile.link.md",
+          "value": "Medium 14px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.fontWeights.medium} {core.fontSize.14}/{core.lineHeights.150percent} {core.fontFamilies.riforma-ll}"
+        },
+        {
+          "key": "--sizing-core-sizing-16",
+          "name": "core.sizing.16",
+          "value": "16px",
+          "type": "sizing",
+          "rawValue": "16px"
+        },
+        {
+          "key": "--sizing-core-sizing-24",
+          "name": "core.sizing.24",
+          "value": "24px",
+          "type": "sizing",
+          "rawValue": "24px"
+        },
+        {
+          "key": "--sizing-core-sizing-32",
+          "name": "core.sizing.32",
+          "value": "32px",
+          "type": "sizing",
+          "rawValue": "32px"
+        },
+        {
+          "key": "--borderWidth-core-border-width-1",
+          "name": "core.borderWidth.1",
+          "value": "1px",
+          "type": "borderWidth",
+          "rawValue": "1px"
+        },
+        {
+          "key": "--borderWidth-core-border-width-2",
+          "name": "core.borderWidth.2",
+          "value": "2px",
+          "type": "borderWidth",
+          "rawValue": "2px"
+        },
+        {
+          "key": "--borderWidth-core-border-width-none",
+          "name": "core.borderWidth.none",
+          "value": "0px",
+          "type": "borderWidth",
+          "rawValue": "0px"
+        }
+      ],
+      "parameters": {},
+      "dependencies": []
+    },
+    {
+      "name": "brand--radius",
+      "isStatic": true,
+      "variables": [
+        {
+          "key": "--color-semantic-color-light-actions-default-primary-foreground",
+          "name": "semantic.color.light.actions.default.primaryForeground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{core.color.neutral.50}"
+        },
+        {
+          "key": "--color-semantic-color-light-actions-default-primary-background",
+          "name": "semantic.color.light.actions.default.primaryBackground",
+          "value": "#262626",
+          "type": "color",
+          "rawValue": "{core.color.neutral.900}"
+        },
+        {
+          "key": "--color-semantic-color-light-actions-default-secondary-foreground",
+          "name": "semantic.color.light.actions.default.secondaryForeground",
+          "value": "#262626",
+          "type": "color",
+          "rawValue": "{core.color.neutral.900}"
+        },
+        {
+          "key": "--color-semantic-color-light-actions-default-secondary-background",
+          "name": "semantic.color.light.actions.default.secondaryBackground",
+          "value": "rgba(0,0,0,0)",
+          "type": "color",
+          "rawValue": "{core.color.none}"
+        },
+        {
+          "key": "--color-semantic-color-light-actions-default-border",
+          "name": "semantic.color.light.actions.default.border",
+          "value": "#262626",
+          "type": "color",
+          "rawValue": "{core.color.neutral.900}"
+        },
+        {
+          "key": "--color-semantic-color-light-actions-hover-foreground",
+          "name": "semantic.color.light.actions.hover.foreground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{core.color.neutral.50}"
+        },
+        {
+          "key": "--color-semantic-color-light-actions-hover-background",
+          "name": "semantic.color.light.actions.hover.background",
+          "value": "#D44527",
+          "type": "color",
+          "rawValue": "{core.color.red.500}"
+        },
+        {
+          "key": "--color-semantic-color-light-actions-hover-border",
+          "name": "semantic.color.light.actions.hover.border",
+          "value": "#D44527",
+          "type": "color",
+          "rawValue": "{core.color.red.500}"
+        },
+        {
+          "key": "--color-semantic-color-light-actions-active-foreground",
+          "name": "semantic.color.light.actions.active.foreground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{core.color.neutral.50}"
+        },
+        {
+          "key": "--color-semantic-color-light-actions-active-background",
+          "name": "semantic.color.light.actions.active.background",
+          "value": "#A3331A",
+          "type": "color",
+          "rawValue": "{core.color.red.600}"
+        },
+        {
+          "key": "--color-semantic-color-light-actions-active-border",
+          "name": "semantic.color.light.actions.active.border",
+          "value": "#A3331A",
+          "type": "color",
+          "rawValue": "{core.color.red.600}"
+        },
+        {
+          "key": "--color-semantic-color-light-actions-disabled-primary-background",
+          "name": "semantic.color.light.actions.disabled.primaryBackground",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "{core.color.neutral.500}"
+        },
+        {
+          "key": "--color-semantic-color-light-actions-disabled-primary-foreground",
+          "name": "semantic.color.light.actions.disabled.primaryForeground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{core.color.neutral.50}"
+        },
+        {
+          "key": "--color-semantic-color-light-actions-disabled-secondary-foreground",
+          "name": "semantic.color.light.actions.disabled.secondaryForeground",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "{core.color.neutral.500}"
+        },
+        {
+          "key": "--color-semantic-color-light-actions-disabled-secondary-background",
+          "name": "semantic.color.light.actions.disabled.secondaryBackground",
+          "value": "rgba(0,0,0,0)",
+          "type": "color",
+          "rawValue": "{core.color.none}"
+        },
+        {
+          "key": "--color-semantic-color-light-actions-disabled-border",
+          "name": "semantic.color.light.actions.disabled.border",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "{core.color.neutral.500}"
+        },
+        {
+          "key": "--color-semantic-color-light-containment-image",
+          "name": "semantic.color.light.containment.image",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "{core.color.neutral.500}"
+        },
+        {
+          "key": "--color-semantic-color-light-containment-background",
+          "name": "semantic.color.light.containment.background",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{core.color.neutral.50}"
+        },
+        {
+          "key": "--color-semantic-color-light-containment-header",
+          "name": "semantic.color.light.containment.header",
+          "value": "#262626",
+          "type": "color",
+          "rawValue": "{core.color.neutral.900}"
+        },
+        {
+          "key": "--color-semantic-color-light-containment-eyebrow",
+          "name": "semantic.color.light.containment.eyebrow",
+          "value": "#4D4D4D",
+          "type": "color",
+          "rawValue": "{core.color.neutral.800}"
+        },
+        {
+          "key": "--color-semantic-color-dark-actions-default-primary-foreground",
+          "name": "semantic.color.dark.actions.default.primaryForeground",
+          "value": "#262626",
+          "type": "color",
+          "rawValue": "{core.color.neutral.900}"
+        },
+        {
+          "key": "--color-semantic-color-dark-actions-default-primary-background",
+          "name": "semantic.color.dark.actions.default.primaryBackground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{core.color.neutral.50}"
+        },
+        {
+          "key": "--color-semantic-color-dark-actions-default-secondary-foreground",
+          "name": "semantic.color.dark.actions.default.secondaryForeground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{core.color.neutral.50}"
+        },
+        {
+          "key": "--color-semantic-color-dark-actions-default-secondary-background",
+          "name": "semantic.color.dark.actions.default.secondaryBackground",
+          "value": "rgba(0,0,0,0)",
+          "type": "color",
+          "rawValue": "{core.color.none}"
+        },
+        {
+          "key": "--color-semantic-color-dark-actions-default-border",
+          "name": "semantic.color.dark.actions.default.border",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{core.color.neutral.50}"
+        },
+        {
+          "key": "--color-semantic-color-dark-actions-hover-foreground",
+          "name": "semantic.color.dark.actions.hover.foreground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{core.color.neutral.50}"
+        },
+        {
+          "key": "--color-semantic-color-dark-actions-hover-background",
+          "name": "semantic.color.dark.actions.hover.background",
+          "value": "#D44527",
+          "type": "color",
+          "rawValue": "{core.color.red.500}"
+        },
+        {
+          "key": "--color-semantic-color-dark-actions-hover-border",
+          "name": "semantic.color.dark.actions.hover.border",
+          "value": "#D44527",
+          "type": "color",
+          "rawValue": "{core.color.red.500}"
+        },
+        {
+          "key": "--color-semantic-color-dark-actions-active-foreground",
+          "name": "semantic.color.dark.actions.active.foreground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{core.color.neutral.50}"
+        },
+        {
+          "key": "--color-semantic-color-dark-actions-active-background",
+          "name": "semantic.color.dark.actions.active.background",
+          "value": "#A3331A",
+          "type": "color",
+          "rawValue": "{core.color.red.600}"
+        },
+        {
+          "key": "--color-semantic-color-dark-actions-active-border",
+          "name": "semantic.color.dark.actions.active.border",
+          "value": "#A3331A",
+          "type": "color",
+          "rawValue": "{core.color.red.600}"
+        },
+        {
+          "key": "--color-semantic-color-dark-actions-disabled-primary-background",
+          "name": "semantic.color.dark.actions.disabled.primaryBackground",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "{core.color.neutral.500}"
+        },
+        {
+          "key": "--color-semantic-color-dark-actions-disabled-primary-foreground",
+          "name": "semantic.color.dark.actions.disabled.primaryForeground",
+          "value": "rgba(0,0,0,0)",
+          "type": "color",
+          "rawValue": "{core.color.none}"
+        },
+        {
+          "key": "--color-semantic-color-dark-actions-disabled-secondary-foreground",
+          "name": "semantic.color.dark.actions.disabled.secondaryForeground",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "{core.color.neutral.500}"
+        },
+        {
+          "key": "--color-semantic-color-dark-actions-disabled-secondary-background",
+          "name": "semantic.color.dark.actions.disabled.secondaryBackground",
+          "value": "rgba(0,0,0,0)",
+          "type": "color",
+          "rawValue": "{core.color.none}"
+        },
+        {
+          "key": "--color-semantic-color-dark-actions-disabled-border",
+          "name": "semantic.color.dark.actions.disabled.border",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "{core.color.neutral.500}"
+        },
+        {
+          "key": "--color-semantic-color-dark-containment-image",
+          "name": "semantic.color.dark.containment.image",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "{core.color.neutral.500}"
+        },
+        {
+          "key": "--color-semantic-color-dark-containment-background",
+          "name": "semantic.color.dark.containment.background",
+          "value": "#262626",
+          "type": "color",
+          "rawValue": "{core.color.neutral.900}"
+        },
+        {
+          "key": "--color-semantic-color-dark-containment-header",
+          "name": "semantic.color.dark.containment.header",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{core.color.neutral.50}"
+        },
+        {
+          "key": "--color-semantic-color-dark-containment-eyebrow",
+          "name": "semantic.color.dark.containment.eyebrow",
+          "value": "#F1F3F4",
+          "type": "color",
+          "rawValue": "{core.color.neutral.200}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-desktop-actions-horizontal-gap",
+          "name": "semantic.spacing.desktop.actions.horizontalGap",
+          "value": "8px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.8}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-desktop-actions-vertical-padding",
+          "name": "semantic.spacing.desktop.actions.verticalPadding",
+          "value": "16px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.16}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-desktop-actions-horizontal-padding",
+          "name": "semantic.spacing.desktop.actions.horizontalPadding",
+          "value": "32px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.32}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-desktop-containment-vertical-padding",
+          "name": "semantic.spacing.desktop.containment.verticalPadding",
+          "value": "20px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.20}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-desktop-containment-horizontal-padding",
+          "name": "semantic.spacing.desktop.containment.horizontalPadding",
+          "value": "72px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.72}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-desktop-containment-image-gap",
+          "name": "semantic.spacing.desktop.containment.imageGap",
+          "value": "24px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.24}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-desktop-containment-button-gap",
+          "name": "semantic.spacing.desktop.containment.buttonGap",
+          "value": "32px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.32}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-desktop-containment-content-gap",
+          "name": "semantic.spacing.desktop.containment.contentGap",
+          "value": "8px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.8}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-tablet-actions-horizontal-gap",
+          "name": "semantic.spacing.tablet.actions.horizontalGap",
+          "value": "8px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.8}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-tablet-actions-vertical-padding",
+          "name": "semantic.spacing.tablet.actions.verticalPadding",
+          "value": "12px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.12}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-tablet-actions-horizontal-padding",
+          "name": "semantic.spacing.tablet.actions.horizontalPadding",
+          "value": "24px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.24}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-tablet-containment-vertical-padding",
+          "name": "semantic.spacing.tablet.containment.verticalPadding",
+          "value": "104px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.104}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-tablet-containment-horizontal-padding",
+          "name": "semantic.spacing.tablet.containment.horizontalPadding",
+          "value": "40px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.40}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-tablet-containment-image-gap",
+          "name": "semantic.spacing.tablet.containment.imageGap",
+          "value": "24px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.24}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-tablet-containment-button-gap",
+          "name": "semantic.spacing.tablet.containment.buttonGap",
+          "value": "32px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.32}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-tablet-containment-content-gap",
+          "name": "semantic.spacing.tablet.containment.contentGap",
+          "value": "8px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.8}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-mobile-actions-horizontal-gap",
+          "name": "semantic.spacing.mobile.actions.horizontalGap",
+          "value": "8px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.8}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-mobile-actions-vertical-padding",
+          "name": "semantic.spacing.mobile.actions.verticalPadding",
+          "value": "8px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.8}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-mobile-actions-horizontal-padding",
+          "name": "semantic.spacing.mobile.actions.horizontalPadding",
+          "value": "16px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.16}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-mobile-containment-vertical-padding",
+          "name": "semantic.spacing.mobile.containment.verticalPadding",
+          "value": "104px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.104}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-mobile-containment-horizontal-padding",
+          "name": "semantic.spacing.mobile.containment.horizontalPadding",
+          "value": "16px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.16}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-mobile-containment-image-gap",
+          "name": "semantic.spacing.mobile.containment.imageGap",
+          "value": "24px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.24}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-mobile-containment-button-gap",
+          "name": "semantic.spacing.mobile.containment.buttonGap",
+          "value": "32px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.32}"
+        },
+        {
+          "key": "--spacing-semantic-spacing-mobile-containment-content-gap",
+          "name": "semantic.spacing.mobile.containment.contentGap",
+          "value": "8px",
+          "type": "spacing",
+          "rawValue": "{core.spacing.8}"
+        },
+        {
+          "key": "--typography-semantic-typography-desktop-actions-label",
+          "name": "semantic.typography.desktop.actions.label",
+          "value": "Medium 20px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.typography.desktop.btn.md}"
+        },
+        {
+          "key": "--typography-semantic-typography-desktop-containment-header",
+          "name": "semantic.typography.desktop.containment.header",
+          "value": "Bold 80px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.typography.desktop.heading.xxl}"
+        },
+        {
+          "key": "--typography-semantic-typography-desktop-containment-eyebrow",
+          "name": "semantic.typography.desktop.containment.eyebrow",
+          "value": "Regular 24px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.typography.desktop.body.xl}"
+        },
+        {
+          "key": "--typography-semantic-typography-tablet-actions-label",
+          "name": "semantic.typography.tablet.actions.label",
+          "value": "Medium 18px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.typography.tablet.btn.md}"
+        },
+        {
+          "key": "--typography-semantic-typography-tablet-containment-header",
+          "name": "semantic.typography.tablet.containment.header",
+          "value": "Bold 64px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.typography.tablet.heading.xxl}"
+        },
+        {
+          "key": "--typography-semantic-typography-tablet-containment-eyebrow",
+          "name": "semantic.typography.tablet.containment.eyebrow",
+          "value": "Regular 20px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.typography.tablet.body.xl}"
+        },
+        {
+          "key": "--typography-semantic-typography-mobile-actions-label",
+          "name": "semantic.typography.mobile.actions.label",
+          "value": "Medium 16px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.typography.mobile.btn.md}"
+        },
+        {
+          "key": "--typography-semantic-typography-mobile-containment-header",
+          "name": "semantic.typography.mobile.containment.header",
+          "value": "Bold 40px/100% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.typography.mobile.heading.xxl}"
+        },
+        {
+          "key": "--typography-semantic-typography-mobile-containment-eyebrow",
+          "name": "semantic.typography.mobile.containment.eyebrow",
+          "value": "Regular 20px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.typography.mobile.body.xl}"
+        },
+        {
+          "key": "--borderRadius-semantic-border-radius-actions-border",
+          "name": "semantic.borderRadius.actions.border",
+          "value": "0px",
+          "type": "borderRadius",
+          "rawValue": "{core.borderRadius.none}"
+        },
+        {
+          "key": "--borderWidth-semantic-border-width-actions-border",
+          "name": "semantic.borderWidth.actions.border",
+          "value": "1px",
+          "type": "borderWidth",
+          "rawValue": "{core.borderWidth.1}"
+        },
+        {
+          "key": "--sizing-semantic-sizing-images-and-icons-icons-default",
+          "name": "semantic.sizing.imagesAndIcons.icons.default",
+          "value": "16px",
+          "type": "sizing",
+          "rawValue": "{core.sizing.16}"
+        },
+        {
+          "key": "--sizing-semantic-sizing-images-and-icons-icons-large",
+          "name": "semantic.sizing.imagesAndIcons.icons.large",
+          "value": "24px",
+          "type": "sizing",
+          "rawValue": "{core.sizing.24}"
+        },
+        {
+          "key": "--sizing-semantic-sizing-images-and-icons-icons-huge",
+          "name": "semantic.sizing.imagesAndIcons.icons.huge",
+          "value": "32px",
+          "type": "sizing",
+          "rawValue": "{core.sizing.32}"
+        }
+      ],
+      "parameters": {},
+      "dependencies": []
+    },
+    {
+      "name": "mode--light",
+      "isStatic": false,
+      "variables": [
+        {
+          "key": "--color-semantic-theme-color-actions-default-primary-foreground",
+          "name": "semanticTheme.color.actions.default.primaryForeground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.default.primaryForeground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-default-primary-background",
+          "name": "semanticTheme.color.actions.default.primaryBackground",
+          "value": "#262626",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.default.primaryBackground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-default-secondary-foreground",
+          "name": "semanticTheme.color.actions.default.secondaryForeground",
+          "value": "#262626",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.default.secondaryForeground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-default-secondary-background",
+          "name": "semanticTheme.color.actions.default.secondaryBackground",
+          "value": "rgba(0,0,0,0)",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.default.secondaryBackground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-default-border",
+          "name": "semanticTheme.color.actions.default.border",
+          "value": "#262626",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.default.border}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-hover-foreground",
+          "name": "semanticTheme.color.actions.hover.foreground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.hover.foreground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-hover-background",
+          "name": "semanticTheme.color.actions.hover.background",
+          "value": "#D44527",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.hover.background}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-hover-border",
+          "name": "semanticTheme.color.actions.hover.border",
+          "value": "#D44527",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.hover.border}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-active-foreground",
+          "name": "semanticTheme.color.actions.active.foreground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.active.foreground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-active-background",
+          "name": "semanticTheme.color.actions.active.background",
+          "value": "#A3331A",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.active.background}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-active-border",
+          "name": "semanticTheme.color.actions.active.border",
+          "value": "#A3331A",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.active.border}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-disabled-primary-background",
+          "name": "semanticTheme.color.actions.disabled.primaryBackground",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.disabled.primaryBackground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-disabled-primary-foreground",
+          "name": "semanticTheme.color.actions.disabled.primaryForeground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.disabled.primaryForeground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-disabled-secondary-foreground",
+          "name": "semanticTheme.color.actions.disabled.secondaryForeground",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.disabled.secondaryForeground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-disabled-secondary-background",
+          "name": "semanticTheme.color.actions.disabled.secondaryBackground",
+          "value": "rgba(0,0,0,0)",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.disabled.secondaryBackground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-disabled-border",
+          "name": "semanticTheme.color.actions.disabled.border",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.disabled.border}"
+        },
+        {
+          "key": "--color-semantic-theme-color-containment-image",
+          "name": "semanticTheme.color.containment.image",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "{semantic.color.light.containment.image}"
+        },
+        {
+          "key": "--color-semantic-theme-color-containment-background",
+          "name": "semanticTheme.color.containment.background",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{semantic.color.light.containment.background}"
+        },
+        {
+          "key": "--color-semantic-theme-color-containment-header",
+          "name": "semanticTheme.color.containment.header",
+          "value": "#262626",
+          "type": "color",
+          "rawValue": "{semantic.color.light.containment.header}"
+        },
+        {
+          "key": "--color-semantic-theme-color-containment-eyebrow",
+          "name": "semanticTheme.color.containment.eyebrow",
+          "value": "#4D4D4D",
+          "type": "color",
+          "rawValue": "{semantic.color.light.containment.eyebrow}"
+        },
+        {
+          "key": "--other-section-name",
+          "name": "section-name",
+          "value": "Light Mode",
+          "type": "other",
+          "rawValue": "Light Mode"
+        }
+      ],
+      "parameters": {
+        "section-name": "Light Mode"
+      },
+      "dependencies": []
+    },
+    {
+      "name": "mode--dark",
+      "isStatic": false,
+      "variables": [
+        {
+          "key": "--color-semantic-theme-color-actions-default-primary-foreground",
+          "name": "semanticTheme.color.actions.default.primaryForeground",
+          "value": "#262626",
+          "type": "color",
+          "rawValue": "{semantic.color.dark.actions.default.primaryForeground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-default-primary-background",
+          "name": "semanticTheme.color.actions.default.primaryBackground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{semantic.color.dark.actions.default.primaryBackground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-default-secondary-foreground",
+          "name": "semanticTheme.color.actions.default.secondaryForeground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{semantic.color.dark.actions.default.secondaryForeground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-default-secondary-background",
+          "name": "semanticTheme.color.actions.default.secondaryBackground",
+          "value": "rgba(0,0,0,0)",
+          "type": "color",
+          "rawValue": "{semantic.color.dark.actions.default.secondaryBackground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-default-border",
+          "name": "semanticTheme.color.actions.default.border",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{semantic.color.dark.actions.default.border}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-hover-foreground",
+          "name": "semanticTheme.color.actions.hover.foreground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.hover.foreground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-hover-background",
+          "name": "semanticTheme.color.actions.hover.background",
+          "value": "#D44527",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.hover.background}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-hover-border",
+          "name": "semanticTheme.color.actions.hover.border",
+          "value": "#D44527",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.hover.border}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-active-foreground",
+          "name": "semanticTheme.color.actions.active.foreground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.active.foreground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-active-background",
+          "name": "semanticTheme.color.actions.active.background",
+          "value": "#A3331A",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.active.background}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-active-border",
+          "name": "semanticTheme.color.actions.active.border",
+          "value": "#A3331A",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.active.border}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-disabled-primary-background",
+          "name": "semanticTheme.color.actions.disabled.primaryBackground",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.disabled.primaryBackground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-disabled-primary-foreground",
+          "name": "semanticTheme.color.actions.disabled.primaryForeground",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.disabled.primaryForeground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-disabled-secondary-foreground",
+          "name": "semanticTheme.color.actions.disabled.secondaryForeground",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.disabled.secondaryForeground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-disabled-secondary-background",
+          "name": "semanticTheme.color.actions.disabled.secondaryBackground",
+          "value": "rgba(0,0,0,0)",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.disabled.secondaryBackground}"
+        },
+        {
+          "key": "--color-semantic-theme-color-actions-disabled-border",
+          "name": "semanticTheme.color.actions.disabled.border",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "{semantic.color.light.actions.disabled.border}"
+        },
+        {
+          "key": "--color-semantic-theme-color-containment-image",
+          "name": "semanticTheme.color.containment.image",
+          "value": "#CCCCCC",
+          "type": "color",
+          "rawValue": "{semantic.color.dark.containment.image}"
+        },
+        {
+          "key": "--color-semantic-theme-color-containment-background",
+          "name": "semanticTheme.color.containment.background",
+          "value": "#262626",
+          "type": "color",
+          "rawValue": "{semantic.color.dark.containment.background}"
+        },
+        {
+          "key": "--color-semantic-theme-color-containment-header",
+          "name": "semanticTheme.color.containment.header",
+          "value": "#FFFFFF",
+          "type": "color",
+          "rawValue": "{core.color.neutral.50}"
+        },
+        {
+          "key": "--color-semantic-theme-color-containment-eyebrow",
+          "name": "semanticTheme.color.containment.eyebrow",
+          "value": "#F1F3F4",
+          "type": "color",
+          "rawValue": "{semantic.color.dark.containment.eyebrow}"
+        },
+        {
+          "key": "--other-section-name",
+          "name": "section-name",
+          "value": "Dark Mode",
+          "type": "other",
+          "rawValue": "Dark Mode"
+        }
+      ],
+      "parameters": {
+        "section-name": "Dark Mode"
+      },
+      "dependencies": []
+    },
+    {
+      "name": "breakpoint--desktop",
+      "isStatic": false,
+      "variables": [
+        {
+          "key": "--spacing-semantic-theme-spacing-actions-horizontal-gap",
+          "name": "semanticTheme.spacing.actions.horizontalGap",
+          "value": "8px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.desktop.actions.horizontalGap}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-actions-vertical-padding",
+          "name": "semanticTheme.spacing.actions.verticalPadding",
+          "value": "16px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.desktop.actions.verticalPadding}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-actions-horizontal-padding",
+          "name": "semanticTheme.spacing.actions.horizontalPadding",
+          "value": "32px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.desktop.actions.horizontalPadding}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-containment-vertical-padding",
+          "name": "semanticTheme.spacing.containment.verticalPadding",
+          "value": "20px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.desktop.containment.verticalPadding}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-containment-horizontal-padding",
+          "name": "semanticTheme.spacing.containment.horizontalPadding",
+          "value": "72px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.desktop.containment.horizontalPadding}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-containment-image-gap",
+          "name": "semanticTheme.spacing.containment.imageGap",
+          "value": "24px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.desktop.containment.imageGap}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-containment-button-gap",
+          "name": "semanticTheme.spacing.containment.buttonGap",
+          "value": "32px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.desktop.containment.buttonGap}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-containment-content-gap",
+          "name": "semanticTheme.spacing.containment.contentGap",
+          "value": "8px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.desktop.containment.contentGap}"
+        },
+        {
+          "key": "--typography-semantic-theme-typography-actions-label",
+          "name": "semanticTheme.typography.actions.label",
+          "value": "Medium 20px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{semantic.typography.desktop.actions.label}"
+        },
+        {
+          "key": "--typography-semantic-theme-typography-containment-header",
+          "name": "semanticTheme.typography.containment.header",
+          "value": "Bold 80px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{semantic.typography.desktop.containment.header}"
+        },
+        {
+          "key": "--typography-semantic-theme-typography-containment-eyebrow",
+          "name": "semanticTheme.typography.containment.eyebrow",
+          "value": "Regular 24px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{semantic.typography.desktop.containment.eyebrow}"
+        },
+        {
+          "key": "--dimension-screen-min-width",
+          "name": "screen-min-width",
+          "value": "900px",
+          "type": "dimension",
+          "rawValue": "900px"
+        }
+      ],
+      "parameters": {
+        "screen-min-width": "900px"
+      },
+      "dependencies": []
+    },
+    {
+      "name": "breakpoint--tablet",
+      "isStatic": false,
+      "variables": [
+        {
+          "key": "--spacing-semantic-theme-spacing-actions-horizontal-gap",
+          "name": "semanticTheme.spacing.actions.horizontalGap",
+          "value": "8px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.tablet.actions.horizontalGap}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-actions-vertical-padding",
+          "name": "semanticTheme.spacing.actions.verticalPadding",
+          "value": "12px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.tablet.actions.verticalPadding}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-actions-horizontal-padding",
+          "name": "semanticTheme.spacing.actions.horizontalPadding",
+          "value": "24px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.tablet.actions.horizontalPadding}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-containment-vertical-padding",
+          "name": "semanticTheme.spacing.containment.verticalPadding",
+          "value": "104px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.tablet.containment.verticalPadding}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-containment-horizontal-padding",
+          "name": "semanticTheme.spacing.containment.horizontalPadding",
+          "value": "40px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.tablet.containment.horizontalPadding}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-containment-image-gap",
+          "name": "semanticTheme.spacing.containment.imageGap",
+          "value": "24px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.tablet.containment.imageGap}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-containment-button-gap",
+          "name": "semanticTheme.spacing.containment.buttonGap",
+          "value": "32px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.tablet.containment.buttonGap}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-containment-content-gap",
+          "name": "semanticTheme.spacing.containment.contentGap",
+          "value": "8px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.tablet.containment.contentGap}"
+        },
+        {
+          "key": "--typography-semantic-theme-typography-actions-label",
+          "name": "semanticTheme.typography.actions.label",
+          "value": "Medium 18px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.typography.tablet.btn.md}"
+        },
+        {
+          "key": "--typography-semantic-theme-typography-containment-header",
+          "name": "semanticTheme.typography.containment.header",
+          "value": "Bold 64px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{semantic.typography.tablet.containment.header}"
+        },
+        {
+          "key": "--typography-semantic-theme-typography-containment-eyebrow",
+          "name": "semanticTheme.typography.containment.eyebrow",
+          "value": "Regular 20px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{semantic.typography.tablet.containment.eyebrow}"
+        },
+        {
+          "key": "--dimension-screen-min-width",
+          "name": "screen-min-width",
+          "value": "600px",
+          "type": "dimension",
+          "rawValue": "600px"
+        },
+        {
+          "key": "--dimension-screen-max-width",
+          "name": "screen-max-width",
+          "value": "899px",
+          "type": "dimension",
+          "rawValue": "899px"
+        }
+      ],
+      "parameters": {
+        "screen-min-width": "600px",
+        "screen-max-width": "899px"
+      },
+      "dependencies": []
+    },
+    {
+      "name": "breakpoint--mobile",
+      "isStatic": false,
+      "variables": [
+        {
+          "key": "--spacing-semantic-theme-spacing-actions-horizontal-gap",
+          "name": "semanticTheme.spacing.actions.horizontalGap",
+          "value": "8px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.mobile.actions.horizontalGap}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-actions-vertical-padding",
+          "name": "semanticTheme.spacing.actions.verticalPadding",
+          "value": "8px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.mobile.actions.verticalPadding}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-actions-horizontal-padding",
+          "name": "semanticTheme.spacing.actions.horizontalPadding",
+          "value": "16px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.mobile.actions.horizontalPadding}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-containment-vertical-padding",
+          "name": "semanticTheme.spacing.containment.verticalPadding",
+          "value": "104px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.mobile.containment.verticalPadding}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-containment-horizontal-padding",
+          "name": "semanticTheme.spacing.containment.horizontalPadding",
+          "value": "16px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.mobile.containment.horizontalPadding}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-containment-image-gap",
+          "name": "semanticTheme.spacing.containment.imageGap",
+          "value": "24px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.mobile.containment.imageGap}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-containment-button-gap",
+          "name": "semanticTheme.spacing.containment.buttonGap",
+          "value": "32px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.mobile.containment.buttonGap}"
+        },
+        {
+          "key": "--spacing-semantic-theme-spacing-containment-content-gap",
+          "name": "semanticTheme.spacing.containment.contentGap",
+          "value": "8px",
+          "type": "spacing",
+          "rawValue": "{semantic.spacing.mobile.containment.contentGap}"
+        },
+        {
+          "key": "--typography-semantic-theme-typography-actions-label",
+          "name": "semanticTheme.typography.actions.label",
+          "value": "Medium 16px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{core.typography.mobile.btn.md}"
+        },
+        {
+          "key": "--typography-semantic-theme-typography-containment-header",
+          "name": "semanticTheme.typography.containment.header",
+          "value": "Bold 40px/100% Riforma LL",
+          "type": "typography",
+          "rawValue": "{semantic.typography.mobile.containment.header}"
+        },
+        {
+          "key": "--typography-semantic-theme-typography-containment-eyebrow",
+          "name": "semanticTheme.typography.containment.eyebrow",
+          "value": "Regular 20px/150% Riforma LL",
+          "type": "typography",
+          "rawValue": "{semantic.typography.mobile.containment.eyebrow}"
+        },
+        {
+          "key": "--dimension-screen-max-width",
+          "name": "screen-max-width",
+          "value": "599px",
+          "type": "dimension",
+          "rawValue": "599px"
+        }
+      ],
+      "parameters": {
+        "screen-max-width": "599px"
+      },
+      "dependencies": []
+    },
+    {
+      "name": "components--components",
+      "isStatic": true,
+      "variables": [
+        {
+          "key": "--color-component-color-button-primary-default-label",
+          "name": "component.color.button.primary.default.label",
+          "value": "{--color-semantic-theme-color-actions-default-primary-foreground}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.default.primaryForeground}"
+        },
+        {
+          "key": "--color-component-color-button-primary-default-background",
+          "name": "component.color.button.primary.default.background",
+          "value": "{--color-semantic-theme-color-actions-default-primary-background}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.default.primaryBackground}"
+        },
+        {
+          "key": "--color-component-color-button-primary-default-border",
+          "name": "component.color.button.primary.default.border",
+          "value": "{--color-semantic-theme-color-actions-default-border}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.default.border}"
+        },
+        {
+          "key": "--color-component-color-button-primary-hover-label",
+          "name": "component.color.button.primary.hover.label",
+          "value": "{--color-semantic-theme-color-actions-hover-foreground}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.hover.foreground}"
+        },
+        {
+          "key": "--color-component-color-button-primary-hover-background",
+          "name": "component.color.button.primary.hover.background",
+          "value": "{--color-semantic-theme-color-actions-hover-background}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.hover.background}"
+        },
+        {
+          "key": "--color-component-color-button-primary-hover-border",
+          "name": "component.color.button.primary.hover.border",
+          "value": "{--color-semantic-theme-color-actions-hover-border}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.hover.border}"
+        },
+        {
+          "key": "--color-component-color-button-primary-active-label",
+          "name": "component.color.button.primary.active.label",
+          "value": "{--color-semantic-theme-color-actions-active-foreground}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.active.foreground}"
+        },
+        {
+          "key": "--color-component-color-button-primary-active-background",
+          "name": "component.color.button.primary.active.background",
+          "value": "{--color-semantic-theme-color-actions-active-background}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.active.background}"
+        },
+        {
+          "key": "--color-component-color-button-primary-active-border",
+          "name": "component.color.button.primary.active.border",
+          "value": "{--color-semantic-theme-color-actions-active-border}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.active.border}"
+        },
+        {
+          "key": "--color-component-color-button-primary-disabled-label",
+          "name": "component.color.button.primary.disabled.label",
+          "value": "{--color-semantic-theme-color-actions-disabled-primary-foreground}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.disabled.primaryForeground}"
+        },
+        {
+          "key": "--color-component-color-button-primary-disabled-background",
+          "name": "component.color.button.primary.disabled.background",
+          "value": "{--color-semantic-theme-color-actions-disabled-primary-background}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.disabled.primaryBackground}"
+        },
+        {
+          "key": "--color-component-color-button-primary-disabled-border",
+          "name": "component.color.button.primary.disabled.border",
+          "value": "{--color-semantic-theme-color-actions-disabled-border}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.disabled.border}"
+        },
+        {
+          "key": "--color-component-color-button-secondary-default-label",
+          "name": "component.color.button.secondary.default.label",
+          "value": "{--color-semantic-theme-color-actions-default-secondary-foreground}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.default.secondaryForeground}"
+        },
+        {
+          "key": "--color-component-color-button-secondary-default-background",
+          "name": "component.color.button.secondary.default.background",
+          "value": "{--color-semantic-theme-color-actions-default-secondary-background}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.default.secondaryBackground}"
+        },
+        {
+          "key": "--color-component-color-button-secondary-default-border",
+          "name": "component.color.button.secondary.default.border",
+          "value": "{--color-semantic-theme-color-actions-default-border}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.default.border}"
+        },
+        {
+          "key": "--color-component-color-button-secondary-hover-label",
+          "name": "component.color.button.secondary.hover.label",
+          "value": "{--color-semantic-theme-color-actions-hover-foreground}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.hover.foreground}"
+        },
+        {
+          "key": "--color-component-color-button-secondary-hover-background",
+          "name": "component.color.button.secondary.hover.background",
+          "value": "{--color-semantic-theme-color-actions-hover-background}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.hover.background}"
+        },
+        {
+          "key": "--color-component-color-button-secondary-hover-border",
+          "name": "component.color.button.secondary.hover.border",
+          "value": "{--color-semantic-theme-color-actions-hover-border}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.hover.border}"
+        },
+        {
+          "key": "--color-component-color-button-secondary-active-label",
+          "name": "component.color.button.secondary.active.label",
+          "value": "{--color-semantic-theme-color-actions-active-foreground}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.active.foreground}"
+        },
+        {
+          "key": "--color-component-color-button-secondary-active-background",
+          "name": "component.color.button.secondary.active.background",
+          "value": "{--color-semantic-theme-color-actions-active-background}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.active.background}"
+        },
+        {
+          "key": "--color-component-color-button-secondary-active-border",
+          "name": "component.color.button.secondary.active.border",
+          "value": "{--color-semantic-theme-color-actions-active-border}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.active.border}"
+        },
+        {
+          "key": "--color-component-color-button-secondary-disabled-label",
+          "name": "component.color.button.secondary.disabled.label",
+          "value": "{--color-semantic-theme-color-actions-disabled-secondary-foreground}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.disabled.secondaryForeground}"
+        },
+        {
+          "key": "--color-component-color-button-secondary-disabled-background",
+          "name": "component.color.button.secondary.disabled.background",
+          "value": "{--color-semantic-theme-color-actions-disabled-secondary-background}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.disabled.secondaryBackground}"
+        },
+        {
+          "key": "--color-component-color-button-secondary-disabled-border",
+          "name": "component.color.button.secondary.disabled.border",
+          "value": "{--color-semantic-theme-color-actions-disabled-border}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.actions.disabled.border}"
+        },
+        {
+          "key": "--color-component-color-hero-image",
+          "name": "component.color.hero.image",
+          "value": "{--color-semantic-theme-color-containment-image}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.containment.image}"
+        },
+        {
+          "key": "--color-component-color-hero-background",
+          "name": "component.color.hero.background",
+          "value": "{--color-semantic-theme-color-containment-background}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.containment.background}"
+        },
+        {
+          "key": "--color-component-color-hero-header",
+          "name": "component.color.hero.header",
+          "value": "{--color-semantic-theme-color-containment-header}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.containment.header}"
+        },
+        {
+          "key": "--color-component-color-hero-eyebrow",
+          "name": "component.color.hero.eyebrow",
+          "value": "{--color-semantic-theme-color-containment-eyebrow}",
+          "type": "color",
+          "rawValue": "{semanticTheme.color.containment.eyebrow}"
+        },
+        {
+          "key": "--spacing-component-spacing-button-gap",
+          "name": "component.spacing.button.gap",
+          "value": "{--spacing-semantic-theme-spacing-actions-horizontal-gap}",
+          "type": "spacing",
+          "rawValue": "{semanticTheme.spacing.actions.horizontalGap}"
+        },
+        {
+          "key": "--spacing-component-spacing-button-padding-vertical",
+          "name": "component.spacing.button.padding.vertical",
+          "value": "{--spacing-semantic-theme-spacing-actions-vertical-padding}",
+          "type": "spacing",
+          "rawValue": "{semanticTheme.spacing.actions.verticalPadding}"
+        },
+        {
+          "key": "--spacing-component-spacing-button-padding-horizontal",
+          "name": "component.spacing.button.padding.horizontal",
+          "value": "{--spacing-semantic-theme-spacing-actions-horizontal-padding}",
+          "type": "spacing",
+          "rawValue": "{semanticTheme.spacing.actions.horizontalPadding}"
+        },
+        {
+          "key": "--spacing-component-spacing-hero-gap-content",
+          "name": "component.spacing.hero.gap.content",
+          "value": "{--spacing-semantic-theme-spacing-containment-content-gap}",
+          "type": "spacing",
+          "rawValue": "{semanticTheme.spacing.containment.contentGap}"
+        },
+        {
+          "key": "--spacing-component-spacing-hero-gap-above-button",
+          "name": "component.spacing.hero.gap.aboveButton",
+          "value": "{--spacing-semantic-theme-spacing-containment-button-gap}",
+          "type": "spacing",
+          "rawValue": "{semanticTheme.spacing.containment.buttonGap}"
+        },
+        {
+          "key": "--spacing-component-spacing-hero-gap-image",
+          "name": "component.spacing.hero.gap.image",
+          "value": "{--spacing-semantic-theme-spacing-containment-image-gap}",
+          "type": "spacing",
+          "rawValue": "{semanticTheme.spacing.containment.imageGap}"
+        },
+        {
+          "key": "--spacing-component-spacing-hero-padding-horizontal",
+          "name": "component.spacing.hero.padding.horizontal",
+          "value": "{--spacing-semantic-theme-spacing-containment-horizontal-padding}",
+          "type": "spacing",
+          "rawValue": "{semanticTheme.spacing.containment.horizontalPadding}"
+        },
+        {
+          "key": "--spacing-component-spacing-hero-padding-vertical",
+          "name": "component.spacing.hero.padding.vertical",
+          "value": "{--spacing-semantic-theme-spacing-containment-vertical-padding}",
+          "type": "spacing",
+          "rawValue": "{semanticTheme.spacing.containment.verticalPadding}"
+        },
+        {
+          "key": "--borderWidth-component-border-width-button-border",
+          "name": "component.borderWidth.button.border",
+          "value": "1px",
+          "type": "borderWidth",
+          "rawValue": "{semantic.borderWidth.actions.border}"
+        },
+        {
+          "key": "--typography-component-typography-button-label",
+          "name": "component.typography.button.label",
+          "value": "{--typography-semantic-theme-typography-actions-label}",
+          "type": "typography",
+          "rawValue": "{semanticTheme.typography.actions.label}"
+        },
+        {
+          "key": "--typography-component-typography-hero-header",
+          "name": "component.typography.hero.header",
+          "value": "{--typography-semantic-theme-typography-containment-header}",
+          "type": "typography",
+          "rawValue": "{semanticTheme.typography.containment.header}"
+        },
+        {
+          "key": "--typography-component-typography-hero-eyebrow",
+          "name": "component.typography.hero.eyebrow",
+          "value": "{--typography-semantic-theme-typography-containment-eyebrow}",
+          "type": "typography",
+          "rawValue": "{semanticTheme.typography.containment.eyebrow}"
+        },
+        {
+          "key": "--borderRadius-component-border-radius-button-border",
+          "name": "component.borderRadius.button.border",
+          "value": "0px",
+          "type": "borderRadius",
+          "rawValue": "{semantic.borderRadius.actions.border}"
+        },
+        {
+          "key": "--sizing-component-sizing-button-icon",
+          "name": "component.sizing.button.icon",
+          "value": "16px",
+          "type": "sizing",
+          "rawValue": "{semantic.sizing.imagesAndIcons.icons.default}"
+        }
+      ],
+      "parameters": {},
+      "dependencies": [
+        "Light Mode",
+        "Dark Mode"
+      ]
+    }
+  ],
+  "order": [
+    "core",
+    "brand--radius",
+    "mode--light",
+    "mode--dark",
+    "breakpoint--desktop",
+    "breakpoint--tablet",
+    "breakpoint--mobile",
+    "components--components"
+  ]
+}

--- a/library/foundations/package.json
+++ b/library/foundations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rangle/radius-foundations",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "src/index.ts",
   "description": "Foundation scripts and variables for Design Systems",
   "files": [

--- a/library/foundations/scripts/mapping/css-generator.ts
+++ b/library/foundations/scripts/mapping/css-generator.ts
@@ -14,5 +14,10 @@ export default {
         [/Heavy/g, '900'],
       ],
     ],
+    [
+      /--letterSpacing/,
+      // preserve sign ($1), divide value ($2) by 100, replace % with em
+      [[/(-?)([0-9]*)%/g, 'calc($1$2em/100)']],
+    ],
   ],
 } satisfies GeneratorMappingDictionary;


### PR DESCRIPTION
## Changes
- updated Typography component to work with new tokens
- added additional props (eg. `fontFamily`, `lineHeight` which can override the `font` shorthand prop)
- made storybook controls dynamic (hooked up to generated tokens file)
- updated importer to convert letterSpacing `%` values to `em`


Note: also incremented token version to 2.0.3 with the updated hero tokens. This should have been done with https://github.com/rangle/radius-monorepo-react/pull/55