### PR TITLE
Storybook improvements

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,11 +8,8 @@ module.exports = {
       titlePrefix: 'About',
       files: '**/*.mdx',
     },
-    {
-      directory: '../library/core-components/components',
-      titlePrefix: 'Core Components',
-      files: '**/*.stories.*',
-    },
+    // TODO: group stories by CDK/examples here after they have been moved to separate packages
+    '../library/core-components/**/*.stories.tsx',
   ],
   // Add assets, these files will be added to the root of the build (/fonts.css)
   staticDirs: [

--- a/library/core-components/components/auto-layout/auto-layout-alignment.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout-alignment.stories.tsx
@@ -3,11 +3,10 @@ import { Meta } from '@storybook/react';
 import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { RadiusAutoLayout } from './auto-layout';
 import { Stories, Title, Description } from '@storybook/addon-docs';
-import { radiusTokens } from '@rangle/radius-foundations/generated/design-tokens.constants';
 
 const meta: Meta<typeof RadiusAutoLayout> = {
   component: RadiusAutoLayout,
-  title: 'Auto Layout/Alignment',
+  title: 'Component Development Kit / Auto Layout/Alignment',
   parameters: {
     design: {
       type: 'figma',

--- a/library/core-components/components/auto-layout/auto-layout-alignment.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout-alignment.stories.tsx
@@ -55,17 +55,17 @@ const ThreeBoxesTemplateAlignmentHor = {
         <RadiusAutoLayout
           width={args.children.width}
           height={20}
-          fill={radiusTokens.component.color.button.primary.hover.background}
+          fill={{ css: '#D44527' }}
         />
         <RadiusAutoLayout
           width={args.children.width}
           height={40}
-          fill={radiusTokens.component.color.button.primary.hover.background}
+          fill={{ css: '#D44527' }}
         />
         <RadiusAutoLayout
           width={args.children.width}
           height={60}
-          fill={radiusTokens.component.color.button.primary.hover.background}
+          fill={{ css: '#D44527' }}
         />
       </RadiusAutoLayout>
     </RadiusAutoLayout>
@@ -146,21 +146,9 @@ const ThreeBoxesTemplateAlignmentVert = {
         }
         padding={{ css: '12px' }}
       >
-        <RadiusAutoLayout
-          width="25%"
-          height={10}
-          fill={radiusTokens.component.color.button.primary.hover.background}
-        />
-        <RadiusAutoLayout
-          width="50%"
-          height={10}
-          fill={radiusTokens.component.color.button.primary.hover.background}
-        />
-        <RadiusAutoLayout
-          width="75%"
-          height={10}
-          fill={radiusTokens.component.color.button.primary.hover.background}
-        />
+        <RadiusAutoLayout width="25%" height={10} fill={{ css: '#D44527' }} />
+        <RadiusAutoLayout width="50%" height={10} fill={{ css: '#D44527' }} />
+        <RadiusAutoLayout width="75%" height={10} fill={{ css: '#D44527' }} />
       </RadiusAutoLayout>
     </RadiusAutoLayout>
   ),

--- a/library/core-components/components/auto-layout/auto-layout-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout-layout.stories.tsx
@@ -4,11 +4,10 @@ import { Meta } from '@storybook/react';
 import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { RadiusAutoLayout } from './auto-layout';
 import { Title, Stories, Description } from '@storybook/addon-docs';
-import { radiusTokens } from '@rangle/radius-foundations/generated/design-tokens.constants';
 
 const meta: Meta<typeof RadiusAutoLayout> = {
   component: RadiusAutoLayout,
-  title: 'Auto Layout/Layout',
+  title: 'Component Development Kit / Auto Layout/Layout',
   parameters: {
     design: {
       type: 'figma',

--- a/library/core-components/components/auto-layout/auto-layout-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout-layout.stories.tsx
@@ -56,17 +56,17 @@ const ThreeBoxesTemplate = {
         <RadiusAutoLayout
           width={args.children.width}
           height={args.children.height}
-          fill={radiusTokens.component.color.button.primary.hover.background}
+          fill={{ css: '#D44527' }}
         />
         <RadiusAutoLayout
           width={args.children.width}
           height={args.children.height}
-          fill={radiusTokens.component.color.button.primary.hover.background}
+          fill={{ css: '#D44527' }}
         />
         <RadiusAutoLayout
           width={args.children.width}
           height={args.children.height}
-          fill={radiusTokens.component.color.button.primary.hover.background}
+          fill={{ css: '#D44527' }}
         />
       </RadiusAutoLayout>
     </RadiusAutoLayout>

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -109,17 +109,17 @@ export const AutoLayout: Story = {
         <RadiusAutoLayout
           width={100}
           height={args.direction !== 'vertical' ? 'fill-parent' : '25%'}
-          fill={radiusTokens.component.color.button.primary.hover.background}
+          fill={{ css: '#D44527' }}
         />
         <RadiusAutoLayout
           width={100}
           height={args.direction !== 'vertical' ? 'fill-parent' : '25%'}
-          fill={radiusTokens.component.color.button.primary.hover.background}
+          fill={{ css: '#D44527' }}
         />
         <RadiusAutoLayout
           width={100}
           height={args.direction !== 'vertical' ? 'fill-parent' : '25%'}
-          fill={radiusTokens.component.color.button.primary.hover.background}
+          fill={{ css: '#D44527' }}
         />
       </RadiusAutoLayout>
     </div>
@@ -131,9 +131,8 @@ export const AutoLayout: Story = {
     height: 'fill-parent',
     space: 'auto',
     padding: radiusTokens.core.spacing[4],
-    fill: radiusTokens.semanticTheme.color.actions.default.secondaryBackground,
-    stroke:
-      radiusTokens.semanticTheme.color.actions.default.secondaryForeground,
+    fill: { css: 'white' },
+    stroke: { css: 'black' },
     strokeWidth: radiusTokens.core.borderWidth[2],
     cornerRadius: radiusTokens.core.borderRadius.none,
     clippedContent: false,
@@ -155,20 +154,20 @@ export const Padding: Story = {
         width={100}
         height={25}
         padding={{ css: '50px 0 0 20px' }}
-        fill={radiusTokens.component.color.button.primary.hover.background}
+        fill={{ css: '#D44527' }}
       />
 
       <RadiusAutoLayout
         width={100}
         height={25}
         padding={{ css: '30px 0' }}
-        fill={radiusTokens.component.color.button.primary.hover.background}
+        fill={{ css: '#D44527' }}
       />
       <RadiusAutoLayout
         width={100}
         height={25}
         padding={{ css: '48px' }}
-        fill={radiusTokens.component.color.button.primary.hover.background}
+        fill={{ css: '#D44527' }}
       />
     </RadiusAutoLayout>
   ),
@@ -192,38 +191,38 @@ export const Opacity: Story = {
         height={25}
         // @ts-expect-error - opacity type needs refinement
         opacity={radiusTokens.core.opacity['25percent']}
-        stroke={radiusTokens.component.color.button.primary.default.background}
-        fill={radiusTokens.component.color.button.primary.default.background}
+        stroke={{ css: 'black' }}
+        fill={{ css: 'black' }}
       />
       <RadiusAutoLayout
         width={100}
         height={25}
         // @ts-expect-error - opacity type needs refinement
         opacity={radiusTokens.core.opacity['35percent']}
-        stroke={radiusTokens.component.color.button.primary.default.background}
-        fill={radiusTokens.component.color.button.primary.default.background}
+        stroke={{ css: 'black' }}
+        fill={{ css: 'black' }}
       />
       <RadiusAutoLayout
         width={100}
         height={25}
         // @ts-expect-error - opacity type needs refinement
         opacity={radiusTokens.core.opacity['65percent']}
-        stroke={radiusTokens.component.color.button.primary.default.background}
-        fill={radiusTokens.component.color.button.primary.default.background}
+        stroke={{ css: 'black' }}
+        fill={{ css: 'black' }}
       />
       <RadiusAutoLayout
         width={100}
         height={25}
         // @ts-expect-error - opacity type needs refinement
         opacity={radiusTokens.core.opacity['90percent']}
-        stroke={radiusTokens.component.color.button.primary.default.background}
-        fill={radiusTokens.component.color.button.primary.default.background}
+        stroke={{ css: 'black' }}
+        fill={{ css: 'black' }}
       />
       <RadiusAutoLayout
         width={100}
         height={25}
-        stroke={radiusTokens.component.color.button.primary.default.background}
-        fill={radiusTokens.component.color.button.primary.default.background}
+        stroke={{ css: 'black' }}
+        fill={{ css: 'black' }}
       />
     </RadiusAutoLayout>
   ),
@@ -242,16 +241,8 @@ export const BackgroundColor: Story = {
       width="fill-parent"
       padding={{ css: '12px' }}
     >
-      <RadiusAutoLayout
-        width={100}
-        height={25}
-        fill={radiusTokens.component.color.button.primary.default.background}
-      />
-      <RadiusAutoLayout
-        width={100}
-        height={25}
-        fill={radiusTokens.component.color.button.primary.hover.background}
-      />
+      <RadiusAutoLayout width={100} height={25} fill={{ css: 'black' }} />
+      <RadiusAutoLayout width={100} height={25} fill={{ css: '#D44527' }} />
       <RadiusAutoLayout width={100} height={25} fill={{ css: 'red' }} />
       <RadiusAutoLayout width={100} height={25} fill={{ css: '#0000ff' }} />
       <RadiusAutoLayout
@@ -284,23 +275,23 @@ export const Border: Story = {
       <RadiusAutoLayout
         width={50}
         height={50}
-        stroke={radiusTokens.component.color.button.primary.hover.background}
+        stroke={{ css: '#D44527' }}
         // @ts-expect-error - strokeWidth type needs refinement
         strokeWidth={radiusTokens.core.borderWidth['1']}
       />
       <RadiusAutoLayout
         width={50}
         height={50}
-        stroke={radiusTokens.component.color.button.primary.hover.background}
-        strokeAlign={`outside`}
+        stroke={{ css: '#D44527' }}
+        strokeAlign="outside"
         // @ts-expect-error - strokeWidth type needs refinement
         strokeWidth={radiusTokens.core.borderWidth['2']}
       />
       <RadiusAutoLayout
         width={50}
         height={50}
-        stroke={radiusTokens.component.color.button.primary.hover.background}
-        strokeAlign={'inside'}
+        stroke={{ css: '#D44527' }}
+        strokeAlign="inside"
         strokeWidth={{ css: '20px 0 1px 5px' }}
       />
     </RadiusAutoLayout>
@@ -325,21 +316,21 @@ export const BorderRadius: Story = {
         height={50}
         // @ts-expect-error - cornerRadius type needs refinement
         cornerRadius={radiusTokens.core.borderRadius[4]}
-        stroke={radiusTokens.component.color.button.primary.hover.background}
+        stroke={{ css: '#D44527' }}
       />
       <RadiusAutoLayout
         width={50}
         height={50}
         // @ts-expect-error - cornerRadius type needs refinement
         cornerRadius={radiusTokens.core.borderRadius[16]}
-        stroke={radiusTokens.component.color.button.primary.hover.background}
+        stroke={{ css: '#D44527' }}
       />
       <RadiusAutoLayout
         width={50}
         height={50}
         // @ts-expect-error - cornerRadius type needs refinement
         cornerRadius={radiusTokens.core.borderRadius.max}
-        stroke={radiusTokens.component.color.button.primary.hover.background}
+        stroke={{ css: '#D44527' }}
       />
     </RadiusAutoLayout>
   ),
@@ -356,16 +347,16 @@ export const Absolute: Story = {
       direction={'vertical'}
       width={'fill-parent'}
       strokeAlign={'inside'}
-      stroke={radiusTokens.component.color.button.primary.default.background}
+      stroke={{ css: 'black' }}
       padding={{ css: '20px' }}
       isParent={true}
       height={200}
       style={{ fontFamily: 'Riforma LL' }}
     >
       <RadiusAutoLayout
-        fill={radiusTokens.component.color.button.primary.default.background}
+        fill={{ css: 'black' }}
         style={{
-          color: `var(${radiusTokens.component.color.button.primary.default.label})`,
+          color: 'white',
         }}
         padding={{ css: '12px' }}
         absolutePosition={true}
@@ -376,9 +367,9 @@ export const Absolute: Story = {
       </RadiusAutoLayout>
       <RadiusAutoLayout
         padding={{ css: '12px' }}
-        fill={radiusTokens.component.color.button.primary.default.background}
+        fill={{ css: 'black' }}
         style={{
-          color: `var(${radiusTokens.component.color.button.primary.default.label})`,
+          color: 'white',
         }}
         horizontalConstraint="right"
         verticalConstraint="bottom"
@@ -404,35 +395,35 @@ export const AsElements: Story = {
       width="fill-parent"
       padding={{ css: '12px' }}
       style={{
-        color: `var(${radiusTokens.component.color.button.primary.default.label})`,
+        color: 'white',
         fontFamily: 'Riforma LL',
       }}
     >
       <RadiusAutoLayout
         as="h1"
         padding={{ css: '20px' }}
-        fill={radiusTokens.component.color.button.primary.default.background}
+        fill={{ css: 'black' }}
       >
         As h1
       </RadiusAutoLayout>
       <RadiusAutoLayout
         as="main"
         padding={{ css: '20px' }}
-        fill={radiusTokens.component.color.button.primary.default.background}
+        fill={{ css: 'black' }}
       >
         As main
       </RadiusAutoLayout>
       <RadiusAutoLayout
         as="ul"
         padding={{ css: '20px' }}
-        fill={radiusTokens.component.color.button.primary.default.background}
+        fill={{ css: 'black' }}
       >
         As ul
       </RadiusAutoLayout>
       <RadiusAutoLayout
         as="p"
         padding={{ css: '20px' }}
-        fill={radiusTokens.component.color.button.primary.default.background}
+        fill={{ css: 'black' }}
       >
         As paragraph
       </RadiusAutoLayout>
@@ -452,7 +443,7 @@ export const Effects: Story = {
       width="fill-parent"
       padding={{ css: '12px' }}
       style={{
-        color: `var(${radiusTokens.component.color.button.primary.default.background})`,
+        color: `var(${{ css: 'black' }})`,
         fontFamily: 'Riforma LL',
       }}
     >
@@ -479,9 +470,9 @@ export const Effects: Story = {
       <RadiusAutoLayout
         layerBlur={1}
         padding={{ css: '20px' }}
-        fill={radiusTokens.component.color.button.primary.default.background}
+        fill={{ css: 'black' }}
         style={{
-          color: `var(${radiusTokens.component.color.button.primary.default.label})`,
+          color: 'white',
         }}
       >
         layer-blur
@@ -507,9 +498,9 @@ export const Effects: Story = {
         layerBlur={1}
         // @ts-expect-error - dropShadow type needs refinement
         dropShadow={radiusTokens.core.shadow[400]}
-        fill={radiusTokens.component.color.button.primary.default.background}
+        fill={{ css: 'black' }}
         style={{
-          color: `var(${radiusTokens.component.color.button.primary.default.label})`,
+          color: 'white',
         }}
       >
         layer-blur and drop-shadow
@@ -531,7 +522,7 @@ export const Layouts: Story = {
       alignment="center"
       isParent={true}
       style={{
-        color: `var(${radiusTokens.component.color.button.primary.default.background})`,
+        color: `var(${{ css: 'black' }})`,
         fontFamily: 'Riforma LL',
       }}
     >

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -6,6 +6,7 @@ import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { RadiusAutoLayout } from './auto-layout';
 import { RadiusButton } from '../button/button';
 import { flattenObject } from '../../utils';
+import { AutoLayoutExtendedProps } from './auto-layout.types';
 
 const meta: Meta<typeof RadiusAutoLayout> = {
   component: RadiusAutoLayout,
@@ -23,7 +24,7 @@ const meta: Meta<typeof RadiusAutoLayout> = {
     },
     badges: [BADGE.BETA],
     componentSubtitle:
-      "RadiusAutoLayout duplicates Figma's Auto Layout API. In Figma Auto Layout is a very powerful feature that allows you to create complex layouts with ease.  We've adapted its API as a Polymorphic component that will work with many of the features in Auto Layout.",
+      "RadiusAutoLayout duplicates Figma's Auto Layout API. In Figma, Auto Layout is a very powerful feature that allows you to create complex layouts with ease.  We've adapted its API as a Polymorphic component that will work with many of the features in Auto Layout so that decisions made in Figma will be reflected 1:1 in code.",
 
     // More on Storybook parameters at: https://storybook.js.org/docs/react/writing-stories/parameters#component-parameters
   },
@@ -34,10 +35,10 @@ const meta: Meta<typeof RadiusAutoLayout> = {
       table: { defaultValue: { summary: 'div' } },
     },
     width: {
-      options: ['150px', '50%', 'fill-parent', 'hug-contents'],
+      options: ['200px', '50%', 'fill-parent', 'hug-contents'],
     },
     height: {
-      options: ['200px', '50%', 'fill-parent', 'hug-contents'],
+      options: ['150px', '50%', 'fill-parent', 'hug-contents'],
     },
     space: {
       options: ['auto', ...flattenObject(radiusTokens.core.spacing)],
@@ -45,6 +46,9 @@ const meta: Meta<typeof RadiusAutoLayout> = {
     },
     padding: {
       options: ['', ...flattenObject(radiusTokens.core.spacing)],
+    },
+    direction: {
+      options: ['horizontal', 'vertical'],
     },
     fill: {
       options: [
@@ -77,6 +81,19 @@ const meta: Meta<typeof RadiusAutoLayout> = {
     cornerRadius: {
       options: ['', ...flattenObject(radiusTokens.core.borderRadius)],
     },
+    dropShadow: {
+      options: ['', ...flattenObject(radiusTokens.core.shadow)],
+    },
+    innerShadow: {
+      options: ['', ...flattenObject(radiusTokens.core.shadow)],
+    },
+    layerBlur: {
+      options: [0, 1, 2, 3],
+    },
+    backgroundBlur: {
+      options: [0, 1, 2, 3],
+    },
+    // TODO: add grid tokens when ready
     ref: { table: { disable: true } },
   },
 };
@@ -85,37 +102,40 @@ export default meta;
 type Story = StoryObj<typeof RadiusAutoLayout>;
 
 export const AutoLayout: Story = {
-  render: (args) => (
-    <RadiusAutoLayout {...args}>
-      <RadiusAutoLayout
-        width={100}
-        height="fill-parent"
-        fill={radiusTokens.component.color.button.primary.hover.background}
-      />
-      <RadiusAutoLayout
-        width={100}
-        height="fill-parent"
-        fill={radiusTokens.component.color.button.primary.hover.background}
-      />
-      <RadiusAutoLayout
-        width={100}
-        height="fill-parent"
-        fill={radiusTokens.component.color.button.primary.hover.background}
-      />
-    </RadiusAutoLayout>
+  // @ts-expect-error - bug with `args` type inference due to polymorphism
+  render: (args: AutoLayoutExtendedProps) => (
+    <div style={{ display: 'flex', height: 200 }}>
+      <RadiusAutoLayout {...args}>
+        <RadiusAutoLayout
+          width={100}
+          height={args.direction !== 'vertical' ? 'fill-parent' : '25%'}
+          fill={radiusTokens.component.color.button.primary.hover.background}
+        />
+        <RadiusAutoLayout
+          width={100}
+          height={args.direction !== 'vertical' ? 'fill-parent' : '25%'}
+          fill={radiusTokens.component.color.button.primary.hover.background}
+        />
+        <RadiusAutoLayout
+          width={100}
+          height={args.direction !== 'vertical' ? 'fill-parent' : '25%'}
+          fill={radiusTokens.component.color.button.primary.hover.background}
+        />
+      </RadiusAutoLayout>
+    </div>
   ),
   args: {
     as: 'div',
     alignment: 'top',
     width: 'fill-parent',
-    height: '200px',
+    height: 'fill-parent',
     space: 'auto',
     padding: radiusTokens.core.spacing[4],
     fill: radiusTokens.semanticTheme.color.actions.default.secondaryBackground,
     stroke:
       radiusTokens.semanticTheme.color.actions.default.secondaryForeground,
     strokeWidth: radiusTokens.core.borderWidth[2],
-    cornerRadius: '--borderRadius-core-radius-none',
+    cornerRadius: radiusTokens.core.borderRadius.none,
     clippedContent: false,
     isParent: false,
     absolutePosition: false,
@@ -170,6 +190,7 @@ export const Opacity: Story = {
       <RadiusAutoLayout
         width={100}
         height={25}
+        // @ts-expect-error - opacity type needs refinement
         opacity={radiusTokens.core.opacity['25percent']}
         stroke={radiusTokens.component.color.button.primary.default.background}
         fill={radiusTokens.component.color.button.primary.default.background}
@@ -177,6 +198,7 @@ export const Opacity: Story = {
       <RadiusAutoLayout
         width={100}
         height={25}
+        // @ts-expect-error - opacity type needs refinement
         opacity={radiusTokens.core.opacity['35percent']}
         stroke={radiusTokens.component.color.button.primary.default.background}
         fill={radiusTokens.component.color.button.primary.default.background}
@@ -184,6 +206,7 @@ export const Opacity: Story = {
       <RadiusAutoLayout
         width={100}
         height={25}
+        // @ts-expect-error - opacity type needs refinement
         opacity={radiusTokens.core.opacity['65percent']}
         stroke={radiusTokens.component.color.button.primary.default.background}
         fill={radiusTokens.component.color.button.primary.default.background}
@@ -191,6 +214,7 @@ export const Opacity: Story = {
       <RadiusAutoLayout
         width={100}
         height={25}
+        // @ts-expect-error - opacity type needs refinement
         opacity={radiusTokens.core.opacity['90percent']}
         stroke={radiusTokens.component.color.button.primary.default.background}
         fill={radiusTokens.component.color.button.primary.default.background}
@@ -261,6 +285,7 @@ export const Border: Story = {
         width={50}
         height={50}
         stroke={radiusTokens.component.color.button.primary.hover.background}
+        // @ts-expect-error - strokeWidth type needs refinement
         strokeWidth={radiusTokens.core.borderWidth['1']}
       />
       <RadiusAutoLayout
@@ -268,6 +293,7 @@ export const Border: Story = {
         height={50}
         stroke={radiusTokens.component.color.button.primary.hover.background}
         strokeAlign={`outside`}
+        // @ts-expect-error - strokeWidth type needs refinement
         strokeWidth={radiusTokens.core.borderWidth['2']}
       />
       <RadiusAutoLayout
@@ -297,18 +323,21 @@ export const BorderRadius: Story = {
       <RadiusAutoLayout
         width={50}
         height={50}
+        // @ts-expect-error - cornerRadius type needs refinement
         cornerRadius={radiusTokens.core.borderRadius[4]}
         stroke={radiusTokens.component.color.button.primary.hover.background}
       />
       <RadiusAutoLayout
         width={50}
         height={50}
+        // @ts-expect-error - cornerRadius type needs refinement
         cornerRadius={radiusTokens.core.borderRadius[16]}
         stroke={radiusTokens.component.color.button.primary.hover.background}
       />
       <RadiusAutoLayout
         width={50}
         height={50}
+        // @ts-expect-error - cornerRadius type needs refinement
         cornerRadius={radiusTokens.core.borderRadius.max}
         stroke={radiusTokens.component.color.button.primary.hover.background}
       />
@@ -428,17 +457,21 @@ export const Effects: Story = {
       }}
     >
       <RadiusAutoLayout
+        // @ts-expect-error - dropShadow type needs refinement
         dropShadow={radiusTokens.core.shadow[400]}
         padding={{ css: '20px' }}
         stroke={{ css: '#0005' }}
+        // @ts-expect-error - strokeWidth type needs refinement
         strokeWidth={radiusTokens.core.borderWidth['1']}
       >
         drop-shadow
       </RadiusAutoLayout>
       <RadiusAutoLayout
+        // @ts-expect-error - innerShadow type needs refinement
         innerShadow={radiusTokens.core.shadow[400]}
         padding={{ css: '20px' }}
         stroke={{ css: '#0005' }}
+        // @ts-expect-error - strokeWidth type needs refinement
         strokeWidth={radiusTokens.core.borderWidth['1']}
       >
         inner-shadow
@@ -472,6 +505,7 @@ export const Effects: Story = {
       <RadiusAutoLayout
         padding={{ css: '20px' }}
         layerBlur={1}
+        // @ts-expect-error - dropShadow type needs refinement
         dropShadow={radiusTokens.core.shadow[400]}
         fill={radiusTokens.component.color.button.primary.default.background}
         style={{

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -23,8 +23,6 @@ const meta: Meta<typeof RadiusAutoLayout> = {
       patch: process.env.COMPONENT_VERSION?.[2],
     },
     badges: [BADGE.BETA],
-    componentSubtitle:
-      "RadiusAutoLayout duplicates Figma's Auto Layout API. In Figma, Auto Layout is a very powerful feature that allows you to create complex layouts with ease.  We've adapted its API as a Polymorphic component that will work with many of the features in Auto Layout so that decisions made in Figma will be reflected 1:1 in code.",
 
     // More on Storybook parameters at: https://storybook.js.org/docs/react/writing-stories/parameters#component-parameters
   },

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -10,7 +10,7 @@ import { AutoLayoutExtendedProps } from './auto-layout.types';
 
 const meta: Meta<typeof RadiusAutoLayout> = {
   component: RadiusAutoLayout,
-  title: 'Auto Layout',
+  title: 'Component Development Kit / Auto Layout',
   parameters: {
     design: {
       type: 'figma',

--- a/library/core-components/components/auto-layout/auto-layout.styles.ts
+++ b/library/core-components/components/auto-layout/auto-layout.styles.ts
@@ -1,3 +1,4 @@
+import { CSSExpression } from '@rangle/radius-foundations';
 import { renderCSSProp, css, PickWithRequired } from '../../utils';
 
 import { RadiusAutoLayout } from './auto-layout';
@@ -47,6 +48,20 @@ export const setPosition = (
   }
 
   return out;
+};
+
+/**
+ * Function that returns the `box-shadow` property given the dropShadow and
+ * innerShadow props.
+ */
+const getShadow = (
+  dropShadow: StyleProps['dropShadow'],
+  innerShadow: StyleProps['innerShadow']
+) => {
+  const shadows: CSSExpression[] = [];
+  if (dropShadow) shadows.push(renderCSSProp(dropShadow));
+  if (innerShadow) shadows.push(`inset ${renderCSSProp(innerShadow)}`);
+  return shadows.length ? shadows.join(', ') : undefined;
 };
 
 /** When no item spacing is specified, figma defaults to 10px */
@@ -185,12 +200,11 @@ export const useStyles = ({
     ${stroke || strokeWidth ? 'border-style: solid;' : ''}
     ${stroke ? `border-color: ${renderCSSProp(stroke)};` : ''}
     ${strokeWidth ? `border-width: ${renderCSSProp(strokeWidth)};` : ''}
-    ${cornerRadius ? `border-radius: ${renderCSSProp(cornerRadius)}` : ''}
+    ${cornerRadius ? `border-radius: ${renderCSSProp(cornerRadius)};` : ''}
     ${x !== undefined || y !== undefined
       ? setPosition(x, y, horizontalConstraint, verticalConstraint)
       : ''}
-    ${dropShadow ? `box-shadow: ${renderCSSProp(dropShadow)};` : ''}
-    ${innerShadow ? `box-shadow: inset ${renderCSSProp(innerShadow)};` : ''}
+    box-shadow: ${getShadow(dropShadow, innerShadow)};
     ${layerBlur ? `filter: blur(${getCssValue(layerBlur)});` : ''}
     ${backgroundBlur
       ? `backdrop-filter: blur(${getCssValue(backgroundBlur)});`

--- a/library/core-components/components/auto-layout/auto-layout.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.tsx
@@ -6,6 +6,27 @@ import { PolymorphicRef } from '../../utils/polymorphic.types';
 import { AutoLayoutComponent, AutoLayoutProps } from './auto-layout.types';
 import { useStyles } from './auto-layout.styles';
 
+/**
+ * A component that duplicates Figma's Auto Layout API. In Figma, Auto Layout is
+ * a very powerful feature that allows you to create complex layouts with ease.
+ * We've adapted its API as a Polymorphic component that will work with many of
+ * the features in Auto Layout so that decisions made in Figma will be reflected
+ * 1:1 in code. This has the added benefit of allowing designers to make changes
+ * to the Auto Layout in Figma and have those changes reflected in code without
+ * any additional work.
+ *
+ * Since the Auto Layout component is polymorphic, it can be used as any HTML
+ * tag, as well as any React component, by passing the `as` prop. For example,
+ * if you want to use the Auto Layout component as an `img` tag, you can do so
+ * by passing `as="img"` to the component. The component will now accept all
+ * attributes of the `img` tag, in addition to the Auto Layout specific
+ * attributes. Similarly, if you want to use the Auto Layout component as a
+ * `RadiusButton`, you can do so by passing `as={RadiusButton}` to the
+ * component.
+ *
+ * ### Resources
+ * [Explore Auto Layout properties](https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties)
+ * */
 export const RadiusAutoLayout: AutoLayoutComponent = forwardRef(
   <C extends React.ElementType = 'div'>(
     {

--- a/library/core-components/components/auto-layout/auto-layout.types.ts
+++ b/library/core-components/components/auto-layout/auto-layout.types.ts
@@ -15,7 +15,6 @@ export const mapAlignments = {
 export const mapStrokeAlign = {
   inside: 'border-box',
   outside: 'content-box',
-  // center: 'content-box',
 };
 
 export type BlendMode =
@@ -35,12 +34,6 @@ export type BlendMode =
   | 'saturation'
   | 'color'
   | 'luminosity';
-
-// effects
-// TODO: narrow these types (in generator)
-export type DropShadow = CSSProp;
-export type InnerShadow = CSSProp;
-export type Blur = Size;
 
 export type Size = number | `${number}px` | `${number}%` | `var(${string})`;
 export type AutolayoutSize = Size | 'fill-parent' | 'hug-contents';
@@ -106,19 +99,15 @@ export type AutoLayoutExtendedProps = {
   strokeWidth?: CSSProp; // TODO: narrow this type
   /** Border alignment, inside or outside. We are missing middle alignment */
   strokeAlign?: StrokeAlign;
-  // strokeSide?: StrokeSide;
-  // strokeCap?: StrokeCap;
 
   /** Border radius, can be number or object of topLeft, topRight, bottomRight, bottomLeft */
   cornerRadius?: CSSProp; // TODO: narrow this type
 
   // effects
-  dropShadow?: DropShadow;
-  innerShadow?: InnerShadow;
-  layerBlur?: Blur;
-  backgroundBlur?: Blur;
-
-  // blendMode?: BlendMode; // not needed
+  dropShadow?: CSSProp; // TODO: narrow this type
+  innerShadow?: CSSProp; // TODO: narrow this type
+  layerBlur?: Size;
+  backgroundBlur?: Size;
 
   /** Whether this AutoLayout should behave as a grid */
   grid?: boolean;

--- a/library/core-components/components/button/button.stories.tsx
+++ b/library/core-components/components/button/button.stories.tsx
@@ -24,9 +24,6 @@ const meta: Meta<typeof RadiusButton> = {
       patch: process.env.COMPONENT_VERSION?.[2],
     },
     badges: [BADGE.BETA],
-
-    componentSubtitle:
-      'This Polymorphic component will style your component to render as a button.',
     // More on Storybook parameters at: https://storybook.js.org/docs/react/writing-stories/parameters#component-parameters
   },
   argTypes: {

--- a/library/core-components/components/button/button.stories.tsx
+++ b/library/core-components/components/button/button.stories.tsx
@@ -11,7 +11,7 @@ import { radiusTokens } from '@rangle/radius-foundations/generated/design-tokens
 
 const meta: Meta<typeof RadiusButton> = {
   component: RadiusButton,
-  title: 'Button',
+  title: 'Radius Examples / Button',
   parameters: {
     design: {
       type: 'figma',

--- a/library/core-components/components/button/button.tsx
+++ b/library/core-components/components/button/button.tsx
@@ -12,15 +12,18 @@ import { Typography } from '../typography/typography';
 import { useStyles } from './button.styles';
 
 // Adding comments before the component will be added to the documentation in storybook.
-/** # RadiusButton Component
+/**
  * A polymorphic component that represents either an html _button_ or _anchor_
  * exposes all attributes of the selected tag, plus the specific attributes
- * declared in the Specific Props type above
+ * declared in the Specific Props type above.
  *
  * Makes use of the react forwardRef function to ensure that the `ref` property is available
  * and points to the html dom element inside.
  *
- * See https://reactjs.org/docs/forwarding-refs.html for more information
+ * See https://reactjs.org/docs/forwarding-refs.html for more information.
+ *
+ * ### Resources
+ * [Figma Design Specs](https://www.figma.com/file/mwknIfsv5oZk5yApkHdja3/Button?type=design&node-id=2-2)
  */
 export const RadiusButton: RadiusButtonComponent = forwardRef(
   <C extends React.ElementType = 'button'>(

--- a/library/core-components/components/footer/footer.stories.tsx
+++ b/library/core-components/components/footer/footer.stories.tsx
@@ -14,7 +14,7 @@ import { RadiusFooter } from './footer';
 
 const meta: Meta<typeof RadiusFooter> = {
   component: RadiusFooter,
-  title: 'Footer',
+  title: 'Radius Examples / Footer',
   parameters: {
     badges: [BADGE.EXPERIMENTAL],
   },

--- a/library/core-components/components/hero/hero.stories.tsx
+++ b/library/core-components/components/hero/hero.stories.tsx
@@ -4,7 +4,7 @@ import { RadiusHero, RadiusHeroProps } from './hero';
 
 const meta: Meta<RadiusHeroProps> = {
   component: RadiusHero,
-  title: 'Hero',
+  title: 'Radius Examples / Hero',
   parameters: {
     badges: [BADGE.BETA],
   },

--- a/library/core-components/components/icon/icon.stories.tsx
+++ b/library/core-components/components/icon/icon.stories.tsx
@@ -9,7 +9,7 @@ import { flattenObject } from '../../utils/flatten.utils';
 
 const meta: Meta<typeof RadiusIcon> = {
   component: RadiusIcon,
-  title: 'Icon',
+  title: 'Component Development Kit / Icon',
   parameters: {
     badges: [BADGE.BETA],
   },

--- a/library/core-components/components/icon/icon.tsx
+++ b/library/core-components/components/icon/icon.tsx
@@ -22,6 +22,9 @@ import { withIcon } from './utils';
  * The `fill` prop can be used to set the color of the icon. The default color
  * is `currentColor`, which means that the icon will inherit the color of the
  * parent element.
+ *
+ * ### Resources
+ * [Figma Design Specs](https://www.figma.com/file/QsjLCOnkQR4lgIxlz2a5Va/Icon?type=design&node-id=11-804)
  */
 export const RadiusIcon = forwardRef<SVGSVGElement, RadiusIconProps>(
   ({ component, path, size, fill, className, ...rest }, ref) => {

--- a/library/core-components/components/image-text-item/image-text-item.stories.tsx
+++ b/library/core-components/components/image-text-item/image-text-item.stories.tsx
@@ -6,7 +6,7 @@ import { RadiusImageTextItemProps } from './image-text-item.types';
 
 const meta: Meta<RadiusImageTextItemProps> = {
   component: RadiusImageTextItem,
-  title: 'ImageTextItem',
+  title: 'Radius Examples / ImageTextItem',
   parameters: {
     badges: [BADGE.EXPERIMENTAL],
   },

--- a/library/core-components/components/image-text-list/image-text-list.stories.tsx
+++ b/library/core-components/components/image-text-list/image-text-list.stories.tsx
@@ -6,7 +6,7 @@ import { RadiusImageTextListProps } from './image-text-list.types';
 
 const meta: Meta<RadiusImageTextListProps> = {
   component: RadiusImageTextList,
-  title: 'ImageTextList',
+  title: 'Radius Examples / ImageTextList',
   parameters: {
     badges: [BADGE.EXPERIMENTAL],
     controls: {

--- a/library/core-components/components/inline-link/inline-link.stories.tsx
+++ b/library/core-components/components/inline-link/inline-link.stories.tsx
@@ -8,7 +8,7 @@ import { RadiusInlineLinkExtendedProps } from './inline-link.types';
 
 const meta: Meta<typeof RadiusInlineLink> = {
   component: RadiusInlineLink,
-  title: 'Inline Link',
+  title: 'Radius Examples / Inline Link',
   parameters: {
     badges: [BADGE.BETA],
   },

--- a/library/core-components/components/link-button/link-button.stories.tsx
+++ b/library/core-components/components/link-button/link-button.stories.tsx
@@ -7,7 +7,7 @@ import { ArrowRight } from '@rangle/radius-foundations/generated/icons';
 
 const meta: Meta<typeof RadiusLinkButton> = {
   component: RadiusLinkButton,
-  title: 'Link Button',
+  title: 'Radius Examples / Link Button',
   parameters: {
     badges: [BADGE.EXPERIMENTAL],
   },

--- a/library/core-components/components/link-icon/link-icon.stories.tsx
+++ b/library/core-components/components/link-icon/link-icon.stories.tsx
@@ -10,7 +10,7 @@ import { RadiusLinkIconExtendedProps } from './link-icon.types';
 
 const meta: Meta<typeof RadiusLinkIcon> = {
   component: RadiusLinkIcon,
-  title: 'Link Icon',
+  title: 'Radius Examples / Link Icon',
   parameters: {
     badges: [BADGE.BETA],
   },

--- a/library/core-components/components/nav-item/nav-item.stories.tsx
+++ b/library/core-components/components/nav-item/nav-item.stories.tsx
@@ -5,7 +5,7 @@ import { RadiusNavItem } from './nav-item';
 
 const meta: Meta<typeof RadiusNavItem> = {
   component: RadiusNavItem,
-  title: 'Nav Item',
+  title: 'Radius Examples / Nav Item',
   parameters: {
     badges: [BADGE.EXPERIMENTAL],
   },

--- a/library/core-components/components/nav/nav.stories.tsx
+++ b/library/core-components/components/nav/nav.stories.tsx
@@ -19,7 +19,7 @@ import { radiusTokens } from '@rangle/radius-foundations/generated/design-tokens
 
 const meta: Meta<typeof RadiusNav> = {
   component: RadiusNav,
-  title: 'Nav',
+  title: 'Radius Examples / Nav',
   parameters: {
     badges: [BADGE.EXPERIMENTAL],
   },

--- a/library/core-components/components/typography/typography.stories.tsx
+++ b/library/core-components/components/typography/typography.stories.tsx
@@ -14,8 +14,6 @@ const meta: Meta<typeof Typography> = {
   title: 'Component Development Kit / Typography',
   parameters: {
     badges: [BADGE.BETA],
-    componentSubtitle:
-      'This Polymorphic component provides an interface to apply styles and semantics to text content.',
   },
   argTypes: {
     children: {

--- a/library/core-components/components/typography/typography.stories.tsx
+++ b/library/core-components/components/typography/typography.stories.tsx
@@ -11,7 +11,7 @@ const bySubtoken =
 
 const meta: Meta<typeof Typography> = {
   component: Typography,
-  title: 'Typography',
+  title: 'Component Development Kit / Typography',
   parameters: {
     badges: [BADGE.BETA],
     componentSubtitle:

--- a/library/core-components/components/typography/typography.tsx
+++ b/library/core-components/components/typography/typography.tsx
@@ -6,10 +6,10 @@ import { PolymorphicRef } from '../../utils/polymorphic.types';
 import { TypographyProps, TypographyComponent } from './typography.types';
 import { useStyles } from './typography.styles';
 
-/** # Typography Component
- * A polymorphic component that represents a text element.
- * Exposes all attributes of the selected tag, plus the specific attributes
- * declared in the Specific Props type above.
+/**
+ * A polymorphic component that provides an interface to apply styles and
+ * semantics to text content. It exposes all attributes of the selected tag,
+ * plus the Typography component-specific attributes.
  *
  * ### Resources
  * [Figma Design Specs](https://www.figma.com/file/zR8HXS88DxQ4rhgwqIn1lh/Radius-Booster---Foundations?type=design&node-id=213-2449)

--- a/library/core-components/components/typography/typography.tsx
+++ b/library/core-components/components/typography/typography.tsx
@@ -10,6 +10,9 @@ import { useStyles } from './typography.styles';
  * A polymorphic component that represents a text element.
  * Exposes all attributes of the selected tag, plus the specific attributes
  * declared in the Specific Props type above.
+ *
+ * ### Resources
+ * [Figma Design Specs](https://www.figma.com/file/zR8HXS88DxQ4rhgwqIn1lh/Radius-Booster---Foundations?type=design&node-id=213-2449)
  */
 export const Typography: TypographyComponent = forwardRef(
   <C extends React.ElementType = 'p'>(


### PR DESCRIPTION
## Changes
- Reorganized stories into two categories - Component Development Kit and Radius Examples
- Removed component tokens from CDK stories in favour of fixed values
- Cleaned up AutoLayout
  - fixed `dropShadow` & `innerShadow` properties - they can now work simultaneously
  - Added description and link to Figma docs
  - removed unused properties/comments
- Added links to Figma specs to all stories