### PR TITLE
Hide NX Cloud access token

### DIFF
--- a/.github/workflows/build-chromatic.yml
+++ b/.github/workflows/build-chromatic.yml
@@ -68,10 +68,10 @@ jobs:
         run: yarn lint:ci
 
       - name: Build projects 🏗
-        run: npx nx affected --parallel=2 --target=build
+        run: NX_CLOUD_AUTH_TOKEN=${{ secrets.NX_CLOUD_AUTH_TOKEN }} npx nx affected --parallel=2 --target=build
 
       - name: Test
-        run: npx nx affected  --parallel=2 --target=test --coverage
+        run: NX_CLOUD_AUTH_TOKEN=${{ secrets.NX_CLOUD_AUTH_TOKEN }} npx nx affected  --parallel=2 --target=test --coverage
 
       - name: Coverage Report
         uses: vebr/jest-lcov-reporter@v0.2.1

--- a/.github/workflows/deployment-pr.yml
+++ b/.github/workflows/deployment-pr.yml
@@ -53,7 +53,7 @@ jobs:
         run: yarn lint:ci
 
       - name: Build Demo App
-        run: npx nx run demo:build
+        run: NX_CLOUD_AUTH_TOKEN=${{ secrets.NX_CLOUD_AUTH_TOKEN }} npx nx run demo:build
 
       - name: Configure AWS credentials for deployment
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -43,8 +43,8 @@ jobs:
         run: npx nx run demo:build
 
       ## Run lint, test, and build for all affected projects
-      - run: npx nx affected --target=lint --parallel=3
-      - run: npx nx affected --target=test --parallel=3 --configuration=ci
+      - run: NX_CLOUD_AUTH_TOKEN=${{ secrets.NX_CLOUD_AUTH_TOKEN }} npx nx affected --target=lint --parallel=3
+      - run: NX_CLOUD_AUTH_TOKEN=${{ secrets.NX_CLOUD_AUTH_TOKEN }} npx nx affected --target=test --parallel=3 --configuration=ci
 
       - name: Configure AWS credentials for deployment
         uses: aws-actions/configure-aws-credentials@v1

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ apps/**/.cache
 # Generated files (should be built on server)
 library/foundations/generated/*
 !library/foundations/generated/token-layers-*.json
+
+# Environment Variables
+*.env

--- a/README.md
+++ b/README.md
@@ -19,7 +19,16 @@ yarn install
 ```
 This command installs all the necessary packages and dependencies required for the project.
 
-### 3. Connect monorepo package dependencies
+### 3. Set up NX Cloud
+Before you can start working with NX Cloud, you need to create an nx-cloud.env file in the root directory. This file should contain the NX Cloud authentication token key. Here's how to set it up:
+
+``` bash
+echo "NX_CLOUD_AUTH_TOKEN=<your-nx-cloud-token>" > nx-cloud.env
+```
+
+Replace <your-nx-cloud-token> with your actual NX Cloud token. This sets up NX Cloud for the project.
+
+### 4. Connect monorepo package dependencies
 After installing the dependencies, you need to connect the monorepo package dependencies using the following command:
 
 ``` bash
@@ -27,7 +36,7 @@ yarn bootstrap
 ```
 This command links the packages within the monorepo, ensuring that they work together seamlessly.
 
-### 4. Run Storybook
+### 5. Run Storybook
 To view and test the components, run the Storybook development server with the following command:
 
 ``` bash
@@ -35,7 +44,7 @@ yarn storybook
 ```
 This command launches the Storybook server, which provides an interactive, visual environment to explore and test the components in isolation. You can access the Storybook by opening a web browser and navigating to http://localhost:6006.
 
-### 5. Run the demo app
+### 6. Run the demo app
 To see the components in action, you can run the demo app by executing the following command:
 
 ``` bash

--- a/nx.json
+++ b/nx.json
@@ -8,8 +8,7 @@
           "build",
           "test",
           "dev"
-        ],
-        "accessToken": "N2ZmNDhhYWYtOTEwZS00YjM1LTkwYmItNjBiN2U5ODk1OTU1fHJlYWQtd3JpdGU="
+        ]
       }
     }
   },


### PR DESCRIPTION
The NX Cloud access token was exposed in `nx.json` - it has now been removed in favour of an environment variable. A new token has been generated and the old one is no longer valid.
- See updated instructions in README for adding token locally
- Token has also been added to github as a secret and integrated with github actions where relevant