### PR TITLE
AutoLayout storybook improvements

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -25,7 +25,6 @@ module.exports = {
     '@storybook/addon-interactions',
     'storybook-addon-pseudo-states',
     '@geometricpanda/storybook-addon-badges',
-    '@storybook/addon-mdx-gfm',
   ],
   framework: {
     name: '@storybook/react-webpack5',

--- a/library/core-components/components/auto-layout/auto-layout-alignment.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout-alignment.stories.tsx
@@ -6,12 +6,8 @@ import { Stories, Title, Description } from '@storybook/addon-docs';
 
 const meta: Meta<typeof RadiusAutoLayout> = {
   component: RadiusAutoLayout,
-  title: 'Component Development Kit / Auto Layout/Alignment',
+  title: 'Component Development Kit / Auto Layout / Alignment',
   parameters: {
-    design: {
-      type: 'figma',
-      url: 'https://www.figma.com/file/????',
-    },
     // Version is rendered by this plugin https://github.com/silversonicaxel/storybook-addon-versioning
     version: {
       major: process.env.COMPONENT_VERSION?.[0],

--- a/library/core-components/components/auto-layout/auto-layout-height-and-width.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout-height-and-width.stories.tsx
@@ -19,6 +19,8 @@ import { AutoLayoutExtendedProps } from './auto-layout.types';
  *
  * ## Resources
  * [How Figma Resizing Works](https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties#resizing)
+ *
+ * [RadiusAutoLayout Figma Specs](https://www.figma.com/file/ODAUZaQxH8oH2GI0A9MAVb/Radius-Booster---Auto-Layout?type=design&node-id=1312-1170&t=Fh2ap7gIybG92aBU-0)
  */
 const meta: Meta<typeof RadiusAutoLayout> = {
   component: RadiusAutoLayout,

--- a/library/core-components/components/auto-layout/auto-layout-height-and-width.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout-height-and-width.stories.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
+import { RadiusAutoLayout } from './auto-layout';
+import { AutoLayoutExtendedProps } from './auto-layout.types';
+
+/**
+ * RadiusAutoLayout duplicates the behaviour of Figma Auto Layout's
+ * Width and Height properties.
+ *
+ * Notes:
+ * - For `fill-parent` to work, the parent must have a defined width or
+ * height (depending on which property you're setting).
+ * - The `hug-contents` property requires the parent container to be a
+ * flex-container (ie. a `RadiusAutoLayout` component), with the `direction`
+ * property set to same direction as the child. Otherwise, the children will
+ * behave as if `fill-parent` was set.
+ *
+ * ## Resources
+ * [How Figma Resizing Works](https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties#resizing)
+ */
+const meta: Meta<typeof RadiusAutoLayout> = {
+  component: RadiusAutoLayout,
+  title: 'Component Development Kit / Auto Layout / Width and Height',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/????',
+    },
+    // Version is rendered by this plugin https://github.com/silversonicaxel/storybook-addon-versioning
+    version: {
+      major: process.env.COMPONENT_VERSION?.[0],
+      minor: process.env.COMPONENT_VERSION?.[1],
+      patch: process.env.COMPONENT_VERSION?.[2],
+    },
+    badges: [BADGE.BETA],
+    controls: {
+      // only show controls relevant to this story
+      include: ['width', 'height', 'direction'],
+    },
+  },
+  argTypes: {
+    direction: {
+      options: ['horizontal', 'vertical'],
+    },
+    width: {
+      options: ['400px', 'hug-contents', '50%', 'fill-parent'],
+      if: { arg: 'direction', eq: 'horizontal' },
+    },
+    height: {
+      options: ['400px', 'hug-contents', '50%', 'fill-parent'],
+      if: { arg: 'direction', eq: 'vertical' },
+    },
+  },
+  args: {
+    direction: 'horizontal',
+    width: 'fill-parent',
+    height: 'fill-parent',
+  },
+  decorators: [
+    (Story, context) => (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection:
+            context.args.direction === 'vertical' ? 'column' : 'row',
+          height: context.args.direction === 'vertical' ? 500 : undefined,
+          width: context.args.direction === 'vertical' ? 374 : undefined,
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof RadiusAutoLayout>;
+
+const WidthAndHeightDemo = ({
+  height,
+  width,
+  direction,
+}: {
+  direction?: AutoLayoutExtendedProps['direction'];
+  width?: AutoLayoutExtendedProps['width'];
+  height?: AutoLayoutExtendedProps['height'];
+}) => {
+  return (
+    <RadiusAutoLayout
+      width={width}
+      height={height}
+      stroke={{ css: '#A6A6A6' }}
+      strokeWidth={{ css: `1px` }}
+      padding={{ css: '10px' }}
+      direction={direction}
+      space="auto"
+    >
+      <RadiusAutoLayout
+        width={direction === 'horizontal' ? 64 : 352}
+        height={direction === 'horizontal' ? 352 : 64}
+        fill={{ css: '#F7856E' }}
+        style={{ zIndex: 1 }}
+      />
+      <RadiusAutoLayout
+        width={direction === 'horizontal' ? 64 : 352}
+        height={direction === 'horizontal' ? 352 : 64}
+        fill={{ css: '#F7856E' }}
+        style={{ zIndex: 1 }}
+      />
+      <RadiusAutoLayout
+        width={direction === 'horizontal' ? 64 : 352}
+        height={direction === 'horizontal' ? 352 : 64}
+        fill={{ css: '#F7856E' }}
+        style={{ zIndex: 1 }}
+      />
+    </RadiusAutoLayout>
+  );
+};
+
+export const WidthAndHeight: Story = {
+  // @ts-expect-error - bug with `args` type inference due to polymorphism
+  render: ({ direction, height, width }: AutoLayoutExtendedProps) => (
+    <WidthAndHeightDemo direction={direction} height={height} width={width} />
+  ),
+};
+
+export const FixedWidth: Story = {
+  ...WidthAndHeight,
+  args: {
+    width: '400px',
+  },
+};
+
+export const HugContents: Story = {
+  ...WidthAndHeight,
+  args: {
+    width: 'hug-contents',
+  },
+};
+
+export const FiftyPercent: Story = {
+  ...WidthAndHeight,
+  args: {
+    width: '50%',
+  },
+};
+
+export const FillParent: Story = {
+  ...WidthAndHeight,
+  args: {
+    width: 'fill-parent',
+  },
+};

--- a/library/core-components/components/auto-layout/auto-layout-height-and-width.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout-height-and-width.stories.tsx
@@ -24,10 +24,6 @@ const meta: Meta<typeof RadiusAutoLayout> = {
   component: RadiusAutoLayout,
   title: 'Component Development Kit / Auto Layout / Width and Height',
   parameters: {
-    design: {
-      type: 'figma',
-      url: 'https://www.figma.com/file/????',
-    },
     // Version is rendered by this plugin https://github.com/silversonicaxel/storybook-addon-versioning
     version: {
       major: process.env.COMPONENT_VERSION?.[0],

--- a/library/core-components/components/auto-layout/auto-layout-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout-layout.stories.tsx
@@ -13,6 +13,8 @@ import { AutoLayoutExtendedProps } from './auto-layout.types';
  * [How Figma Direction Works](https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties#direction)
  *
  * [How Figma Spacing Works](https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties#spacing-between)
+ *
+ * [RadiusAutoLayout Figma Specs](https://www.figma.com/file/ODAUZaQxH8oH2GI0A9MAVb/Radius-Booster---Auto-Layout?type=design&node-id=1312-1092&t=Fh2ap7gIybG92aBU-0)
  */
 const meta: Meta<typeof RadiusAutoLayout> = {
   component: RadiusAutoLayout,

--- a/library/core-components/components/auto-layout/auto-layout-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout-layout.stories.tsx
@@ -16,12 +16,8 @@ import { AutoLayoutExtendedProps } from './auto-layout.types';
  */
 const meta: Meta<typeof RadiusAutoLayout> = {
   component: RadiusAutoLayout,
-  title: 'Component Development Kit / Auto Layout/Layout',
+  title: 'Component Development Kit / Auto Layout / Layout',
   parameters: {
-    design: {
-      type: 'figma',
-      url: 'https://www.figma.com/file/????',
-    },
     // Version is rendered by this plugin https://github.com/silversonicaxel/storybook-addon-versioning
     version: {
       major: process.env.COMPONENT_VERSION?.[0],

--- a/library/core-components/components/auto-layout/auto-layout-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout-layout.stories.tsx
@@ -95,7 +95,9 @@ const LayoutDemo = ({
 }) => {
   return (
     <RadiusAutoLayout
-      width={CONTAINER_WIDTH}
+      style={{
+        maxWidth: CONTAINER_WIDTH,
+      }}
       stroke={{ css: '#A6A6A6' }}
       strokeWidth={{ css: `${BORDER_WIDTH}px` }}
       height={direction === 'vertical' ? CONTAINER_HEIGHT : undefined}

--- a/library/core-components/components/auto-layout/auto-layout-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout-layout.stories.tsx
@@ -1,10 +1,19 @@
-import React, { ComponentProps } from 'react';
-import { Meta } from '@storybook/react';
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
 
 import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { RadiusAutoLayout } from './auto-layout';
-import { Title, Stories, Description } from '@storybook/addon-docs';
+import { AutoLayoutExtendedProps } from './auto-layout.types';
 
+/**
+ * RadiusAutoLayout duplicates the behaviour of Figma Auto Layout's
+ * Direction and Spacing properties.
+ *
+ * ## Resources
+ * [How Figma Direction Works](https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties#direction)
+ *
+ * [How Figma Spacing Works](https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties#spacing-between)
+ */
 const meta: Meta<typeof RadiusAutoLayout> = {
   component: RadiusAutoLayout,
   title: 'Component Development Kit / Auto Layout/Layout',
@@ -20,177 +29,147 @@ const meta: Meta<typeof RadiusAutoLayout> = {
       patch: process.env.COMPONENT_VERSION?.[2],
     },
     badges: [BADGE.BETA],
-    docs: {
-      page: () => (
-        <>
-          <Title>Layout</Title>
-          <Description children="We duplicate the way Figma arranges Auto Layout components."></Description>
-          <Stories includePrimary={true} />
-        </>
-      ),
+    controls: {
+      // only show controls relevant to this story
+      include: ['direction', 'space', 'width', 'height'],
     },
+  },
+  argTypes: {
+    direction: {
+      options: ['horizontal', 'vertical'],
+    },
+    space: {
+      options: {
+        auto: 'auto',
+        '0px': { css: '0px' },
+        '10px': { css: '10px' },
+        '80px': { css: '80px' },
+      },
+      table: { defaultValue: { summary: '10px' } },
+    },
+    width: {
+      options: {
+        fixed: '40px',
+        'fill-parent': 'fill-parent',
+      },
+      description:
+        'The width of the children. Usually controls the parent, this is just for this example.',
+      table: {
+        defaultValue: { summary: null },
+      },
+      if: { arg: 'direction', eq: 'horizontal' },
+    },
+    height: {
+      options: {
+        fixed: '40px',
+        'fill-parent': 'fill-parent',
+      },
+      description:
+        'The height of the children. Usually controls the parent, this is just for this example.',
+      table: {
+        defaultValue: { summary: null },
+      },
+      if: { arg: 'direction', eq: 'vertical' },
+    },
+  },
+  args: {
+    direction: 'horizontal',
+    space: 'auto',
   },
 };
 
 export default meta;
-// type Story = StoryObj<typeof RadiusAutoLayout>;
-// TODO: apply `Story` type to all stories - causes issues due to parent and children args not existing in original component
+type Story = StoryObj<typeof RadiusAutoLayout>;
 
-const ThreeBoxesTemplate = {
-  render: (args: {
-    parent: ComponentProps<typeof RadiusAutoLayout>;
-    children: ComponentProps<typeof RadiusAutoLayout>;
-  }) => (
-    <RadiusAutoLayout direction="vertical">
+const PADDING = 24;
+const BORDER_WIDTH = 1;
+const CONTAINER_WIDTH = 629;
+const CONTAINER_HEIGHT = 388;
+
+const LayoutDemo = ({
+  direction,
+  space,
+  childWidth,
+  childHeight,
+}: {
+  direction?: AutoLayoutExtendedProps['direction'];
+  space?: AutoLayoutExtendedProps['space'];
+  childWidth?: AutoLayoutExtendedProps['width'];
+  childHeight?: AutoLayoutExtendedProps['height'];
+}) => {
+  return (
+    <RadiusAutoLayout
+      width={CONTAINER_WIDTH}
+      stroke={{ css: '#A6A6A6' }}
+      strokeWidth={{ css: `${BORDER_WIDTH}px` }}
+      height={direction === 'vertical' ? CONTAINER_HEIGHT : undefined}
+      padding={{ css: `${PADDING}px` }}
+      alignment="center"
+      isParent
+      direction={direction}
+      space={space}
+    >
       <RadiusAutoLayout
-        direction={args.parent.direction}
-        space={args.parent.space}
-        alignment={args.parent.alignment}
-        width="fill-parent"
-        height={
-          args.parent.direction === 'horizontal' ? 'fill-parent' : '100px'
-        }
-        padding={{ css: '12px' }}
-      >
-        <RadiusAutoLayout
-          width={args.children.width}
-          height={args.children.height}
-          fill={{ css: '#D44527' }}
-        />
-        <RadiusAutoLayout
-          width={args.children.width}
-          height={args.children.height}
-          fill={{ css: '#D44527' }}
-        />
-        <RadiusAutoLayout
-          width={args.children.width}
-          height={args.children.height}
-          fill={{ css: '#D44527' }}
-        />
-      </RadiusAutoLayout>
+        width={direction === 'horizontal' ? childWidth ?? 40 : 'fill-parent'}
+        height={direction === 'horizontal' ? 242 : childHeight ?? 40}
+        fill={{ css: '#F7856E' }}
+        style={{ zIndex: 1 }}
+      />
+      <RadiusAutoLayout
+        width={direction === 'horizontal' ? childWidth ?? 40 : 'fill-parent'}
+        height={direction === 'horizontal' ? 242 : childHeight ?? 40}
+        fill={{ css: '#F7856E' }}
+        style={{ zIndex: 1 }}
+      />
+      <RadiusAutoLayout
+        width={direction === 'horizontal' ? childWidth ?? 40 : 'fill-parent'}
+        height={direction === 'horizontal' ? 242 : childHeight ?? 40}
+        fill={{ css: '#F7856E' }}
+        style={{ zIndex: 1 }}
+      />
     </RadiusAutoLayout>
+  );
+};
+
+export const HorizontalFixedWidthChildrenWithAutoSpacing = {
+  render: ({ direction, space, height, width }: AutoLayoutExtendedProps) => (
+    <LayoutDemo
+      direction={direction}
+      space={space}
+      childWidth={width}
+      childHeight={height}
+    />
   ),
 };
 
-export const FixedWidthHorizontal = {
-  ...ThreeBoxesTemplate,
-  args: {
-    parent: {
-      direction: 'horizontal',
-      space: 'auto',
-      alignment: 'top',
-    },
-    children: {
-      width: 100,
-      height: 25,
-    },
-  },
-  parameters: {
-    controls: {
-      disable: true,
-    },
-    table: {
-      disable: true,
-    },
-  },
+export const HorizontalFixedWidthChildrenWithDefinedSpacing: Story = {
+  render: () => <LayoutDemo direction="horizontal" space={{ css: '80px' }} />,
 };
 
-export const FixedWidthHorizontalDefinedSpacing = {
-  ...ThreeBoxesTemplate,
-  args: {
-    parent: {
-      direction: 'horizontal',
-      space: '--spacing-core-space-3x',
-      alignment: 'top',
-    },
-    children: {
-      width: 100,
-      height: 25,
-    },
-  },
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
+export const HorizontalFillWidthChildrenWithDefinedSpacing: Story = {
+  render: () => (
+    <LayoutDemo
+      direction="horizontal"
+      space={{ css: '80px' }}
+      childWidth="fill-parent"
+    />
+  ),
 };
 
-export const FillWidthHorizontal = {
-  ...ThreeBoxesTemplate,
-  args: {
-    parent: {
-      direction: 'horizontal',
-      space: '--spacing-core-space-base',
-      alignment: 'top',
-    },
-    children: {
-      width: 'fill-parent',
-      height: 25,
-    },
-  },
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
+export const VerticalFixedHeightChildrenWithAutoSpacing: Story = {
+  render: () => <LayoutDemo direction="vertical" space="auto" />,
 };
 
-export const FixedHeightVertical = {
-  ...ThreeBoxesTemplate,
-  args: {
-    parent: {
-      direction: 'vertical',
-      space: 'auto',
-      alignment: 'left',
-    },
-    children: {
-      width: '100%',
-      height: 10,
-    },
-  },
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
+export const VerticalFixedHeightChildrenWithDefinedSpacing: Story = {
+  render: () => <LayoutDemo direction="vertical" space={{ css: '50px' }} />,
 };
 
-export const FixedHeightVerticalDefinedSpacing = {
-  ...ThreeBoxesTemplate,
-  args: {
-    parent: {
-      direction: 'vertical',
-      space: '--spacing-core-space-5x',
-      alignment: 'left',
-    },
-    children: {
-      width: '100%',
-      height: 10,
-    },
-  },
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
-};
-
-export const FillHeightVertical = {
-  ...ThreeBoxesTemplate,
-  args: {
-    parent: {
-      direction: 'vertical',
-      space: '--spacing-core-space-base',
-      alignment: 'left',
-    },
-    children: {
-      width: '100%',
-      height: 'fill-parent',
-    },
-  },
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
+export const VerticalFillHeightChildrenWithDefinedSpacing: Story = {
+  render: () => (
+    <LayoutDemo
+      direction="vertical"
+      space={{ css: '50px' }}
+      childHeight="fill-parent"
+    />
+  ),
 };

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -34,7 +34,7 @@ const meta: Meta<typeof RadiusAutoLayout> = {
       table: { defaultValue: { summary: 'div' } },
     },
     width: {
-      options: ['200px', '50%', 'fill-parent', 'hug-contents'],
+      options: ['629px', '200px', '50%', 'fill-parent', 'hug-contents'],
     },
     height: {
       options: ['150px', '50%', 'fill-parent', 'hug-contents'],
@@ -52,6 +52,7 @@ const meta: Meta<typeof RadiusAutoLayout> = {
     fill: {
       options: [
         '',
+        ...flattenObject(radiusTokens.core.color),
         ...flattenObject(radiusTokens.semantic.color),
         ...flattenObject(radiusTokens.semanticTheme.color),
         ...flattenObject(radiusTokens.component.color),
@@ -60,6 +61,7 @@ const meta: Meta<typeof RadiusAutoLayout> = {
     stroke: {
       options: [
         '',
+        ...flattenObject(radiusTokens.core.color),
         ...flattenObject(radiusTokens.semantic.color),
         ...flattenObject(radiusTokens.semanticTheme.color),
         ...flattenObject(radiusTokens.component.color),
@@ -112,40 +114,62 @@ export default meta;
 type Story = StoryObj<typeof RadiusAutoLayout>;
 
 export const AutoLayout: Story = {
+  parameters: {
+    controls: {
+      // exclude grid controls until we've aligned on the direction we want to go with it
+      exclude: [
+        'grid',
+        'gridColSpan',
+        'gridColStart',
+        'gridColEnd',
+        'gridRowSpan',
+        'gridRowStart',
+        'gridRowEnd',
+      ],
+    },
+  },
   // @ts-expect-error - bug with `args` type inference due to polymorphism
   render: (args: AutoLayoutExtendedProps) => (
-    <div style={{ display: 'flex', height: 200 }}>
-      <RadiusAutoLayout {...args}>
+    <RadiusAutoLayout
+      height={args.direction === 'vertical' ? 388 : undefined}
+      width="fill-parent"
+    >
+      <RadiusAutoLayout alignment="center" isParent {...args}>
         <RadiusAutoLayout
-          width={100}
-          height={args.direction !== 'vertical' ? 'fill-parent' : '25%'}
-          fill={{ css: '#D44527' }}
+          width={args.direction === 'horizontal' ? 40 : 'fill-parent'}
+          height={args.direction === 'horizontal' ? 242 : 40}
+          fill={{ css: '#F7856E' }}
+          style={{ zIndex: 1 }}
         />
         <RadiusAutoLayout
-          width={100}
-          height={args.direction !== 'vertical' ? 'fill-parent' : '25%'}
-          fill={{ css: '#D44527' }}
+          width={args.direction === 'horizontal' ? 40 : 'fill-parent'}
+          height={args.direction === 'horizontal' ? 242 : 40}
+          fill={{ css: '#F7856E' }}
+          style={{ zIndex: 1 }}
         />
         <RadiusAutoLayout
-          width={100}
-          height={args.direction !== 'vertical' ? 'fill-parent' : '25%'}
-          fill={{ css: '#D44527' }}
+          width={args.direction === 'horizontal' ? 40 : 'fill-parent'}
+          height={args.direction === 'horizontal' ? 242 : 40}
+          fill={{ css: '#F7856E' }}
+          style={{ zIndex: 1 }}
         />
       </RadiusAutoLayout>
-    </div>
+    </RadiusAutoLayout>
   ),
   args: {
     as: 'div',
-    alignment: 'top',
-    width: 'fill-parent',
+    width: '629px',
     height: 'fill-parent',
     space: 'auto',
-    padding: radiusTokens.core.spacing[4],
-    fill: { css: 'white' },
-    stroke: { css: 'black' },
-    strokeWidth: radiusTokens.core.borderWidth[2],
+    padding: radiusTokens.core.spacing[24],
+    direction: 'horizontal',
+    fill: radiusTokens.core.color.neutral[50],
+    stroke: radiusTokens.core.color.neutral[600],
+    strokeWidth: radiusTokens.core.borderWidth[1],
+    strokeAlign: 'inside',
     cornerRadius: radiusTokens.core.borderRadius.none,
     clippedContent: false,
+    alignment: 'top',
     isParent: false,
     absolutePosition: false,
     horizontalConstraint: 'left',

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -711,54 +711,59 @@ export const AbsolutePositionAndConstraints: Story = {
   ),
 };
 
-export const AsElements: Story = {
-  render: () => (
+/**
+ * RadiusAutoLayout is polymorphic, which means that it can render as any HTML
+ * element or React component. The `as` property controls what is rendered. By
+ * default, it renders a `div` element.
+ *
+ * The component will extend the props of the element or component that it is
+ * rendering (along with the default props of `RadiusAutoLayout`). For example,
+ * if you set `as="h1"`, the component will accept all the props of the `h1`
+ * element. If you set `as={RadiusButton}`, the component will accept all the
+ * props of the `RadiusButton` component.
+ */
+export const Polymorphism: Story = {
+  // @ts-expect-error - bug with `args` type inference due to polymorphism
+  render: (props: AutoLayoutExtendedProps) => (
     <RadiusAutoLayout
-      direction="horizontal"
+      direction="vertical"
       width="fill-parent"
-      padding={{ css: '12px' }}
       style={{
-        color: 'white',
         fontFamily: 'Riforma LL',
       }}
     >
-      <RadiusAutoLayout
-        as="h1"
-        padding={{ css: '20px' }}
-        fill={{ css: 'black' }}
-      >
-        As h1
+      <RadiusAutoLayout as="h1" {...props}>
+        Heading
+      </RadiusAutoLayout>
+      <RadiusAutoLayout as="a" href="#" {...props}>
+        Link
       </RadiusAutoLayout>
       <RadiusAutoLayout
-        as="main"
-        padding={{ css: '20px' }}
-        fill={{ css: 'black' }}
-      >
-        As main
-      </RadiusAutoLayout>
-      <RadiusAutoLayout
-        as="ul"
-        padding={{ css: '20px' }}
-        fill={{ css: 'black' }}
-      >
-        As ul
-      </RadiusAutoLayout>
-      <RadiusAutoLayout
-        as="p"
-        padding={{ css: '20px' }}
-        fill={{ css: 'black' }}
-      >
-        As paragraph
+        as="img"
+        src="https://via.placeholder.com/1500"
+        height="200px"
+        {...props}
+      />
+      <RadiusAutoLayout as={RadiusButton} variant="primary" {...props}>
+        RadiusButton
       </RadiusAutoLayout>
     </RadiusAutoLayout>
   ),
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
 };
 
+/**
+ * Figma has four types of effects: Drop Shadow, Inner Shadow, Layer Blur,
+ * and Background Blur.
+ *
+ * Drop Shadow (`dropShadow`) and Inner Shadow (`innerShadow`) represent the
+ * shadow on the inside and outside of an element, respectively, and use the
+ * `box-shadow` CSS property. Layer Blur (`layerBlur`) represents the blur
+ * applied to the entire element, using the `filter` CSS property. Background
+ * Blur (`backgroundBlur`) represents the blur applied to the background of the
+ * element, using the `backdrop-filter` CSS property.
+ *
+ * [How Figma Effects Work](https://help.figma.com/hc/en-us/articles/360041488473-Apply-shadow-or-blur-effects)
+ */
 export const Effects: Story = {
   render: () => (
     <RadiusAutoLayout

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -307,27 +307,44 @@ export const Opacity: Story = {
   },
 };
 
-export const BackgroundColor: Story = {
+export const Fill: Story = {
   render: () => (
-    <RadiusAutoLayout
-      direction="horizontal"
-      alignment="top"
-      width="fill-parent"
-      padding={{ css: '12px' }}
-    >
-      <RadiusAutoLayout width={100} height={25} fill={{ css: 'black' }} />
-      <RadiusAutoLayout width={100} height={25} fill={{ css: '#D44527' }} />
-      <RadiusAutoLayout width={100} height={25} fill={{ css: 'red' }} />
-      <RadiusAutoLayout width={100} height={25} fill={{ css: '#0000ff' }} />
+    <RadiusAutoLayout width="fill-parent">
       <RadiusAutoLayout
-        width={100}
-        height={25}
-        fill={{ css: 'rgba(255, 150, 150, 20)' }}
+        width={200}
+        height={200}
+        cornerRadius={{ css: '12px' }}
+        stroke={{ css: '#006C95' }}
+        strokeWidth={{ css: '3px' }}
+        // @ts-expect-error - core tokens are not allowed
+        fill={radiusTokens.core.color.red[400]}
       />
       <RadiusAutoLayout
-        width={100}
-        height={25}
-        fill={{ css: 'rgba(150, 255, 150, 0.2)' }}
+        width={200}
+        height={200}
+        cornerRadius={{ css: '12px' }}
+        stroke={{ css: '#006C95' }}
+        strokeWidth={{ css: '3px' }}
+        // @ts-expect-error - core tokens are not allowed
+        fill={radiusTokens.core.color.orange[50]}
+      />
+      <RadiusAutoLayout
+        width={200}
+        height={200}
+        cornerRadius={{ css: '12px' }}
+        stroke={{ css: '#006C95' }}
+        strokeWidth={{ css: '3px' }}
+        // @ts-expect-error - core tokens are not allowed
+        fill={radiusTokens.core.color.blue[50]}
+      />
+      <RadiusAutoLayout
+        width={200}
+        height={200}
+        cornerRadius={{ css: '12px' }}
+        stroke={{ css: '#006C95' }}
+        strokeWidth={{ css: '3px' }}
+        // @ts-expect-error - core tokens are not allowed
+        fill={radiusTokens.core.color.green[100]}
       />
     </RadiusAutoLayout>
   ),

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -567,20 +567,37 @@ export const ClippedContent: Story = {
  * relative to the viewport.
  *
  * [How Figma Absolute Positioning Works](https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties#h_01G2RPRBBKVKXK0JV59NCSKEE0)
+ *
+ * When an element is absolutely positioned, the `horizontalConstraint` and
+ * `verticalConstraint` properties control how the element is positioned when
+ * the parent is resized. The `horizontalConstraint` property controls the
+ * horizontal position of the element, and the `verticalConstraint` property
+ * controls the vertical position of the element. Note that we are currently
+ * missing some functionality from Figma (`left and right`, `top and bottom`,
+ * `center`, and `scale`)
+ *
+ * [How Figma Constraints Work](https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties#Constraints_and_resizing)
  */
-export const AbsolutePosition: Story = {
+export const AbsolutePositionAndConstraints: Story = {
   parameters: {
     controls: {
       // only show controls relevant to this story
-      include: ['x', 'y'],
+      include: ['x', 'y', 'horizontalConstraint', 'verticalConstraint'],
     },
   },
   args: {
     x: '157px',
     y: '82px',
+    horizontalConstraint: 'left',
+    verticalConstraint: 'top',
   },
   // @ts-expect-error - bug with `args` type inference due to polymorphism
-  render: ({ x, y }: AutoLayoutExtendedProps) => (
+  render: ({
+    x,
+    y,
+    horizontalConstraint,
+    verticalConstraint,
+  }: AutoLayoutExtendedProps) => (
     <RadiusAutoLayout
       stroke={{ css: '#006C95' }}
       strokeWidth={{ css: '3px' }}
@@ -605,6 +622,8 @@ export const AbsolutePosition: Story = {
         absolutePosition
         x={x}
         y={y}
+        horizontalConstraint={horizontalConstraint}
+        verticalConstraint={verticalConstraint}
       >
         <span
           style={{

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -201,50 +201,103 @@ export const Padding: Story = {
 
 export const Opacity: Story = {
   render: () => (
-    <RadiusAutoLayout
-      direction="horizontal"
-      alignment="top"
-      width="fill-parent"
-      padding={{ css: '12px' }}
-    >
+    <RadiusAutoLayout width="fill-parent">
       <RadiusAutoLayout
-        width={100}
-        height={25}
-        // @ts-expect-error - opacity type needs refinement
-        opacity={radiusTokens.core.opacity['25percent']}
-        stroke={{ css: 'black' }}
-        fill={{ css: 'black' }}
-      />
-      <RadiusAutoLayout
-        width={100}
-        height={25}
-        // @ts-expect-error - opacity type needs refinement
-        opacity={radiusTokens.core.opacity['35percent']}
-        stroke={{ css: 'black' }}
-        fill={{ css: 'black' }}
-      />
-      <RadiusAutoLayout
-        width={100}
-        height={25}
-        // @ts-expect-error - opacity type needs refinement
-        opacity={radiusTokens.core.opacity['65percent']}
-        stroke={{ css: 'black' }}
-        fill={{ css: 'black' }}
-      />
-      <RadiusAutoLayout
-        width={100}
-        height={25}
+        width={200}
+        height={200}
+        cornerRadius={{ css: '12px' }}
         // @ts-expect-error - opacity type needs refinement
         opacity={radiusTokens.core.opacity['90percent']}
-        stroke={{ css: 'black' }}
-        fill={{ css: 'black' }}
-      />
+        stroke={{ css: '#006C95' }}
+        strokeWidth={{ css: '3px' }}
+        fill={{ css: '#262626' }}
+        alignment="center"
+        style={{
+          justifyContent: 'center', // only needed until alignment changes are merged
+        }}
+      >
+        <span
+          style={{
+            color: 'white',
+            fontFamily: 'Riforma LL',
+            fontSize: '20px',
+          }}
+        >
+          90%
+        </span>
+      </RadiusAutoLayout>
       <RadiusAutoLayout
-        width={100}
-        height={25}
-        stroke={{ css: 'black' }}
-        fill={{ css: 'black' }}
-      />
+        width={200}
+        height={200}
+        cornerRadius={{ css: '12px' }}
+        // @ts-expect-error - opacity type needs refinement
+        opacity={radiusTokens.core.opacity['65percent']}
+        stroke={{ css: '#006C95' }}
+        strokeWidth={{ css: '3px' }}
+        fill={{ css: '#262626' }}
+        alignment="center"
+        style={{
+          justifyContent: 'center', // only needed until alignment changes are merged
+        }}
+      >
+        <span
+          style={{
+            color: 'white',
+            fontFamily: 'Riforma LL',
+            fontSize: '20px',
+          }}
+        >
+          65%
+        </span>
+      </RadiusAutoLayout>
+      <RadiusAutoLayout
+        width={200}
+        height={200}
+        cornerRadius={{ css: '12px' }}
+        // @ts-expect-error - opacity type needs refinement
+        opacity={radiusTokens.core.opacity['35percent']}
+        stroke={{ css: '#006C95' }}
+        strokeWidth={{ css: '3px' }}
+        fill={{ css: '#262626' }}
+        alignment="center"
+        style={{
+          justifyContent: 'center', // only needed until alignment changes are merged
+        }}
+      >
+        <span
+          style={{
+            color: 'white',
+            fontFamily: 'Riforma LL',
+            fontSize: '20px',
+          }}
+        >
+          35%
+        </span>
+      </RadiusAutoLayout>
+      <RadiusAutoLayout
+        width={200}
+        height={200}
+        cornerRadius={{ css: '12px' }}
+        // @ts-expect-error - opacity type needs refinement
+        opacity={radiusTokens.core.opacity['25percent']}
+        stroke={{ css: '#006C95' }}
+        strokeWidth={{ css: '3px' }}
+        fill={{ css: '#262626' }}
+        alignment="center"
+        style={{
+          justifyContent: 'center', // only needed until alignment changes are merged
+        }}
+      >
+        <span
+          style={{
+            color: 'white',
+            fontFamily: 'Riforma LL',
+            fontSize: '20px',
+          }}
+        >
+          25%
+        </span>
+      </RadiusAutoLayout>
     </RadiusAutoLayout>
   ),
   parameters: {

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -477,6 +477,85 @@ export const CornerRadius: Story = {
   ),
 };
 
+/**
+ * The `clippedContent` property controls whether any content that extends
+ * beyond the bounds of the Auto Layout component is clipped or not. This is
+ * equivalent to `overflow: hidden` in CSS.
+ */
+export const ClippedContent: Story = {
+  parameters: {
+    controls: {
+      // only show controls relevant to this story
+      include: ['clippedContent'],
+    },
+  },
+  // @ts-expect-error - bug with `args` type inference due to polymorphism
+  render: ({ clippedContent }: AutoLayoutExtendedProps) => (
+    <RadiusAutoLayout space={{ css: '70px' }}>
+      <RadiusAutoLayout direction="vertical" alignment="center">
+        <span
+          style={{
+            fontFamily: 'Riforma LL',
+          }}
+        >
+          {!(clippedContent ?? true) ? 'Not ' : ''}Clipped
+        </span>
+        <RadiusAutoLayout
+          width={200}
+          height={200}
+          stroke={{ css: '#006C95' }}
+          strokeWidth={{ css: '3px' }}
+          cornerRadius={{ css: '12px' }}
+          style={{ borderStyle: 'dashed' }}
+          isParent
+          clippedContent={clippedContent ?? true}
+        >
+          <RadiusAutoLayout
+            fill={{ css: '#F7856E' }}
+            width={120}
+            height={100}
+            absolutePosition
+            style={{
+              right: -60,
+              top: 44,
+            }}
+          ></RadiusAutoLayout>
+        </RadiusAutoLayout>
+      </RadiusAutoLayout>
+      <RadiusAutoLayout direction="vertical" alignment="center">
+        <span
+          style={{
+            fontFamily: 'Riforma LL',
+          }}
+        >
+          {!(clippedContent ?? false) ? 'Not ' : ''}Clipped
+        </span>
+        <RadiusAutoLayout
+          width={200}
+          height={200}
+          stroke={{ css: '#006C95' }}
+          strokeWidth={{ css: '3px' }}
+          cornerRadius={{ css: '12px' }}
+          style={{ borderStyle: 'dashed' }}
+          isParent
+          clippedContent={clippedContent ?? false}
+        >
+          <RadiusAutoLayout
+            fill={{ css: '#F7856E' }}
+            width={120}
+            height={100}
+            absolutePosition
+            style={{
+              right: -60,
+              top: 44,
+            }}
+          ></RadiusAutoLayout>
+        </RadiusAutoLayout>
+      </RadiusAutoLayout>
+    </RadiusAutoLayout>
+  ),
+};
+
 export const Absolute: Story = {
   render: () => (
     <RadiusAutoLayout

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -154,6 +154,11 @@ export const AutoLayout: Story = {
 };
 
 /**
+ * The `padding` property controls the padding of the Auto Layout component.
+ * `padding` can be a single value or a list of values. If a list of values is
+ * provided, the values are applied in the following order: top, right, bottom,
+ * left.
+ *
  * [How Figma Padding works](https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties#padding)
  */
 export const Padding: Story = {
@@ -200,15 +205,25 @@ export const Padding: Story = {
   ),
 };
 
+/**
+ * The `opacity` property controls the opacity of the Auto Layout component.
+ * */
 export const Opacity: Story = {
-  render: () => (
+  parameters: {
+    controls: {
+      // only show controls relevant to this story
+      include: ['opacity'],
+    },
+  },
+  // @ts-expect-error - bug with `args` type inference due to polymorphism
+  render: ({ opacity }: AutoLayoutExtendedProps) => (
     <RadiusAutoLayout width="fill-parent">
       <RadiusAutoLayout
         width={200}
         height={200}
         cornerRadius={{ css: '12px' }}
         // @ts-expect-error - opacity type needs refinement
-        opacity={radiusTokens.core.opacity['90percent']}
+        opacity={opacity ?? radiusTokens.core.opacity['90percent']}
         stroke={{ css: '#006C95' }}
         strokeWidth={{ css: '3px' }}
         fill={{ css: '#262626' }}
@@ -232,7 +247,7 @@ export const Opacity: Story = {
         height={200}
         cornerRadius={{ css: '12px' }}
         // @ts-expect-error - opacity type needs refinement
-        opacity={radiusTokens.core.opacity['65percent']}
+        opacity={opacity ?? radiusTokens.core.opacity['65percent']}
         stroke={{ css: '#006C95' }}
         strokeWidth={{ css: '3px' }}
         fill={{ css: '#262626' }}
@@ -256,7 +271,7 @@ export const Opacity: Story = {
         height={200}
         cornerRadius={{ css: '12px' }}
         // @ts-expect-error - opacity type needs refinement
-        opacity={radiusTokens.core.opacity['35percent']}
+        opacity={opacity ?? radiusTokens.core.opacity['35percent']}
         stroke={{ css: '#006C95' }}
         strokeWidth={{ css: '3px' }}
         fill={{ css: '#262626' }}
@@ -280,7 +295,7 @@ export const Opacity: Story = {
         height={200}
         cornerRadius={{ css: '12px' }}
         // @ts-expect-error - opacity type needs refinement
-        opacity={radiusTokens.core.opacity['25percent']}
+        opacity={opacity ?? radiusTokens.core.opacity['25percent']}
         stroke={{ css: '#006C95' }}
         strokeWidth={{ css: '3px' }}
         fill={{ css: '#262626' }}
@@ -301,15 +316,31 @@ export const Opacity: Story = {
       </RadiusAutoLayout>
     </RadiusAutoLayout>
   ),
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
 };
 
+/**
+ * The `fill` property controls the background color of the Auto Layout
+ * component.
+ * */
 export const Fill: Story = {
-  render: () => (
+  parameters: {
+    controls: {
+      // only show controls relevant to this story
+      include: ['fill'],
+    },
+  },
+  argTypes: {
+    fill: {
+      options: {
+        red: { css: 'red' },
+        blue: { css: 'blue' },
+        green: { css: 'green' },
+        orange: { css: 'orange' },
+      },
+    },
+  },
+  // @ts-expect-error - bug with `args` type inference due to polymorphism
+  render: ({ fill }: AutoLayoutExtendedProps) => (
     <RadiusAutoLayout width="fill-parent">
       <RadiusAutoLayout
         width={200}
@@ -318,7 +349,7 @@ export const Fill: Story = {
         stroke={{ css: '#006C95' }}
         strokeWidth={{ css: '3px' }}
         // @ts-expect-error - core tokens are not allowed
-        fill={radiusTokens.core.color.red[400]}
+        fill={fill ?? radiusTokens.core.color.red[400]}
       />
       <RadiusAutoLayout
         width={200}
@@ -327,7 +358,7 @@ export const Fill: Story = {
         stroke={{ css: '#006C95' }}
         strokeWidth={{ css: '3px' }}
         // @ts-expect-error - core tokens are not allowed
-        fill={radiusTokens.core.color.orange[50]}
+        fill={fill ?? radiusTokens.core.color.orange[50]}
       />
       <RadiusAutoLayout
         width={200}
@@ -336,7 +367,7 @@ export const Fill: Story = {
         stroke={{ css: '#006C95' }}
         strokeWidth={{ css: '3px' }}
         // @ts-expect-error - core tokens are not allowed
-        fill={radiusTokens.core.color.blue[50]}
+        fill={fill ?? radiusTokens.core.color.blue[50]}
       />
       <RadiusAutoLayout
         width={200}
@@ -345,15 +376,10 @@ export const Fill: Story = {
         stroke={{ css: '#006C95' }}
         strokeWidth={{ css: '3px' }}
         // @ts-expect-error - core tokens are not allowed
-        fill={radiusTokens.core.color.green[100]}
+        fill={fill ?? radiusTokens.core.color.green[100]}
       />
     </RadiusAutoLayout>
   ),
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
 };
 
 /**

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -13,10 +13,6 @@ const meta: Meta<typeof RadiusAutoLayout> = {
   component: RadiusAutoLayout,
   title: 'Component Development Kit / Auto Layout',
   parameters: {
-    design: {
-      type: 'figma',
-      url: 'https://www.figma.com/file/????',
-    },
     // Version is rendered by this plugin https://github.com/silversonicaxel/storybook-addon-versioning
     version: {
       major: process.env.COMPONENT_VERSION?.[0],

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -418,6 +418,78 @@ export const StrokeAndStrokeWidth: Story = {
 };
 
 /**
+ * The `strokeAlign` property controls whether the border is inside or outside
+ * the bounding dimensions of an element. It can be set to `inside` or
+ * `outside`, which corresponds to `box-sizing: border-box`, and
+ * `box-sizing: content-box` in CSS, respectively. The default value is `inside`.
+ *
+ * [How Figma Stroke Alignment Works](https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties#strokes-in-layout)
+ * */
+export const StrokeAlignment: Story = {
+  parameters: {
+    controls: {
+      // only show controls relevant to this story
+      include: ['strokeAlign'],
+    },
+  },
+  // @ts-expect-error - bug with `args` type inference due to polymorphism
+  render: ({ strokeAlign }: AutoLayoutExtendedProps) => (
+    <RadiusAutoLayout
+      width="fill-parent"
+      space={{ css: '25px' }}
+      alignment="center"
+    >
+      <RadiusAutoLayout direction="vertical" alignment="center">
+        <span
+          style={{
+            fontFamily: 'Riforma LL',
+            fontWeight: 'bold',
+          }}
+        >
+          Stroke Align{' '}
+          {strokeAlign === 'outside' ? 'Outside' : 'Inside (default)'}
+        </span>
+        <RadiusAutoLayout
+          fill={{ css: '#F7856E' }}
+          height={200}
+          width={200}
+          stroke={{ css: '#000000' }}
+          strokeWidth={{ css: '6px' }}
+          style={{
+            outline: '5px dashed #0081B3',
+            outlineOffset: strokeAlign === 'outside' ? '-11px' : '',
+          }}
+          strokeAlign={strokeAlign ?? 'inside'}
+        />
+      </RadiusAutoLayout>
+      <RadiusAutoLayout direction="vertical" alignment="center">
+        <span
+          style={{
+            fontFamily: 'Riforma LL',
+            fontWeight: 'bold',
+          }}
+        >
+          Stroke Align{' '}
+          {strokeAlign === 'inside' ? 'Inside (default)' : 'Outside'}
+        </span>
+        <RadiusAutoLayout
+          fill={{ css: '#F7856E' }}
+          height={200}
+          width={200}
+          stroke={{ css: '#000000' }}
+          strokeWidth={{ css: '6px' }}
+          style={{
+            outline: '5px dashed #0081B3',
+            outlineOffset: strokeAlign === 'inside' ? '' : '-11px',
+          }}
+          strokeAlign={strokeAlign ?? 'outside'}
+        />
+      </RadiusAutoLayout>
+    </RadiusAutoLayout>
+  ),
+};
+
+/**
  * The `cornerRadius` property controls the radius of the corners. `cornerRadius`
  * can be a single value or a list of values. If a list of values is provided,
  * the values are applied in the following order: top-left, top-right,

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -94,6 +94,17 @@ const meta: Meta<typeof RadiusAutoLayout> = {
     // TODO: add grid tokens when ready
     ref: { table: { disable: true } },
   },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          display: 'flex',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export default meta;
@@ -141,39 +152,51 @@ export const AutoLayout: Story = {
   },
 };
 
+/**
+ * [How Figma Padding works](https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties#padding)
+ */
 export const Padding: Story = {
-  render: () => (
-    <RadiusAutoLayout
-      direction="horizontal"
-      alignment="top"
-      width="fill-parent"
-    >
-      <RadiusAutoLayout
-        width={100}
-        height={25}
-        padding={{ css: '50px 0 0 20px' }}
-        fill={{ css: '#D44527' }}
-      />
-
-      <RadiusAutoLayout
-        width={100}
-        height={25}
-        padding={{ css: '30px 0' }}
-        fill={{ css: '#D44527' }}
-      />
-      <RadiusAutoLayout
-        width={100}
-        height={25}
-        padding={{ css: '48px' }}
-        fill={{ css: '#D44527' }}
-      />
-    </RadiusAutoLayout>
-  ),
   parameters: {
     controls: {
-      disable: true,
+      // only show controls relevant to this story
+      include: ['padding'],
     },
   },
+  argTypes: {
+    padding: {
+      options: {
+        '0px': '0px',
+        '10px': { css: '10px' },
+        '48px 24px': { css: '48px 24px' },
+        '10px 20px 30px 40px': { css: '10px 20px 30px 40px' },
+      },
+    },
+  },
+  render: (args) => (
+    <RadiusAutoLayout
+      stroke={{ css: '#006C95' }}
+      strokeWidth={{ css: `2px` }}
+      padding={{ css: '48px 24px' }}
+      style={{
+        borderStyle: 'dashed',
+      }}
+      {...args}
+    >
+      <RadiusAutoLayout
+        width={585}
+        space="auto"
+        stroke={{ css: '#006C95' }}
+        strokeWidth={{ css: `2px` }}
+        style={{
+          borderStyle: 'dashed',
+        }}
+      >
+        <RadiusAutoLayout width={40} height={242} fill={{ css: '#F7856E' }} />
+        <RadiusAutoLayout width={40} height={242} fill={{ css: '#F7856E' }} />
+        <RadiusAutoLayout width={40} height={242} fill={{ css: '#F7856E' }} />
+      </RadiusAutoLayout>
+    </RadiusAutoLayout>
+  ),
 };
 
 export const Opacity: Story = {

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -713,6 +713,104 @@ export const AbsolutePositionAndConstraints: Story = {
 };
 
 /**
+ * Figma has four types of effects: Drop Shadow, Inner Shadow, Layer Blur,
+ * and Background Blur.
+ *
+ * Drop Shadow (`dropShadow`) and Inner Shadow (`innerShadow`) represent the
+ * shadow on the inside and outside of an element, respectively, and use the
+ * `box-shadow` CSS property. Layer Blur (`layerBlur`) represents the blur
+ * applied to the entire element, using the `filter` CSS property. Background
+ * Blur (`backgroundBlur`) represents the blur applied to the background of the
+ * element, using the `backdrop-filter` CSS property.
+ *
+ * [How Figma Effects Work](https://help.figma.com/hc/en-us/articles/360041488473-Apply-shadow-or-blur-effects)
+ */
+export const Effects: Story = {
+  parameters: {
+    controls: {
+      // only show controls relevant to this story
+      include: ['dropShadow', 'innerShadow', 'layerBlur', 'backgroundBlur'],
+    },
+  },
+  // @ts-expect-error - bug with `args` type inference due to polymorphism
+  render: (props: AutoLayoutExtendedProps) => (
+    <RadiusAutoLayout
+      direction="horizontal"
+      width="fill-parent"
+      padding={{ css: '12px' }}
+      style={{
+        color: `var(${{ css: 'black' }})`,
+        fontFamily: 'Riforma LL',
+      }}
+    >
+      <RadiusAutoLayout
+        // @ts-expect-error - dropShadow type needs refinement
+        dropShadow={radiusTokens.core.shadow[400]}
+        padding={{ css: '20px' }}
+        stroke={{ css: '#0005' }}
+        // @ts-expect-error - strokeWidth type needs refinement
+        strokeWidth={radiusTokens.core.borderWidth['1']}
+        {...props}
+      >
+        drop-shadow
+      </RadiusAutoLayout>
+      <RadiusAutoLayout
+        // @ts-expect-error - innerShadow type needs refinement
+        innerShadow={radiusTokens.core.shadow[400]}
+        padding={{ css: '20px' }}
+        stroke={{ css: '#0005' }}
+        // @ts-expect-error - strokeWidth type needs refinement
+        strokeWidth={radiusTokens.core.borderWidth['1']}
+        {...props}
+      >
+        inner-shadow
+      </RadiusAutoLayout>
+      <RadiusAutoLayout
+        layerBlur={1}
+        padding={{ css: '20px' }}
+        fill={{ css: 'black' }}
+        style={{
+          color: 'white',
+        }}
+        {...props}
+      >
+        layer-blur
+      </RadiusAutoLayout>
+      <RadiusAutoLayout
+        style={{
+          backgroundImage:
+            'linear-gradient(45deg, #808080 25%, transparent 25%), linear-gradient(-45deg, #808080 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #808080 75%), linear-gradient(-45deg, transparent 75%, #808080 75%)',
+          backgroundSize: '20px 20px',
+          backgroundPosition: ' 0 0, 0 10px, 10px -10px, -10px 0px',
+        }}
+      >
+        <RadiusAutoLayout
+          style={{ fontWeight: 'bold', fontFamily: 'Riforma LL' }}
+          padding={{ css: '20px' }}
+          backgroundBlur={3}
+          {...props}
+        >
+          background-blur
+        </RadiusAutoLayout>
+      </RadiusAutoLayout>
+      <RadiusAutoLayout
+        padding={{ css: '20px' }}
+        layerBlur={1}
+        // @ts-expect-error - dropShadow type needs refinement
+        dropShadow={radiusTokens.core.shadow[400]}
+        fill={{ css: 'black' }}
+        style={{
+          color: 'white',
+        }}
+        {...props}
+      >
+        layer-blur and drop-shadow
+      </RadiusAutoLayout>
+    </RadiusAutoLayout>
+  ),
+};
+
+/**
  * RadiusAutoLayout is polymorphic, which means that it can render as any HTML
  * element or React component. The `as` property controls what is rendered. By
  * default, it renders a `div` element.
@@ -722,6 +820,8 @@ export const AbsolutePositionAndConstraints: Story = {
  * if you set `as="h1"`, the component will accept all the props of the `h1`
  * element. If you set `as={RadiusButton}`, the component will accept all the
  * props of the `RadiusButton` component.
+ *
+ * Below are a few examples of RadiusAutoLayout being used as other elements.
  */
 export const Polymorphism: Story = {
   // @ts-expect-error - bug with `args` type inference due to polymorphism
@@ -747,92 +847,6 @@ export const Polymorphism: Story = {
       />
       <RadiusAutoLayout as={RadiusButton} variant="primary" {...props}>
         RadiusButton
-      </RadiusAutoLayout>
-    </RadiusAutoLayout>
-  ),
-};
-
-/**
- * Figma has four types of effects: Drop Shadow, Inner Shadow, Layer Blur,
- * and Background Blur.
- *
- * Drop Shadow (`dropShadow`) and Inner Shadow (`innerShadow`) represent the
- * shadow on the inside and outside of an element, respectively, and use the
- * `box-shadow` CSS property. Layer Blur (`layerBlur`) represents the blur
- * applied to the entire element, using the `filter` CSS property. Background
- * Blur (`backgroundBlur`) represents the blur applied to the background of the
- * element, using the `backdrop-filter` CSS property.
- *
- * [How Figma Effects Work](https://help.figma.com/hc/en-us/articles/360041488473-Apply-shadow-or-blur-effects)
- */
-export const Effects: Story = {
-  render: () => (
-    <RadiusAutoLayout
-      direction="horizontal"
-      width="fill-parent"
-      padding={{ css: '12px' }}
-      style={{
-        color: `var(${{ css: 'black' }})`,
-        fontFamily: 'Riforma LL',
-      }}
-    >
-      <RadiusAutoLayout
-        // @ts-expect-error - dropShadow type needs refinement
-        dropShadow={radiusTokens.core.shadow[400]}
-        padding={{ css: '20px' }}
-        stroke={{ css: '#0005' }}
-        // @ts-expect-error - strokeWidth type needs refinement
-        strokeWidth={radiusTokens.core.borderWidth['1']}
-      >
-        drop-shadow
-      </RadiusAutoLayout>
-      <RadiusAutoLayout
-        // @ts-expect-error - innerShadow type needs refinement
-        innerShadow={radiusTokens.core.shadow[400]}
-        padding={{ css: '20px' }}
-        stroke={{ css: '#0005' }}
-        // @ts-expect-error - strokeWidth type needs refinement
-        strokeWidth={radiusTokens.core.borderWidth['1']}
-      >
-        inner-shadow
-      </RadiusAutoLayout>
-      <RadiusAutoLayout
-        layerBlur={1}
-        padding={{ css: '20px' }}
-        fill={{ css: 'black' }}
-        style={{
-          color: 'white',
-        }}
-      >
-        layer-blur
-      </RadiusAutoLayout>
-      <RadiusAutoLayout
-        style={{
-          backgroundImage:
-            'linear-gradient(45deg, #808080 25%, transparent 25%), linear-gradient(-45deg, #808080 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #808080 75%), linear-gradient(-45deg, transparent 75%, #808080 75%)',
-          backgroundSize: '20px 20px',
-          backgroundPosition: ' 0 0, 0 10px, 10px -10px, -10px 0px',
-        }}
-      >
-        <RadiusAutoLayout
-          style={{ fontWeight: 'bold', fontFamily: 'Riforma LL' }}
-          padding={{ css: '20px' }}
-          backgroundBlur={3}
-        >
-          background-blur
-        </RadiusAutoLayout>
-      </RadiusAutoLayout>
-      <RadiusAutoLayout
-        padding={{ css: '20px' }}
-        layerBlur={1}
-        // @ts-expect-error - dropShadow type needs refinement
-        dropShadow={radiusTokens.core.shadow[400]}
-        fill={{ css: 'black' }}
-        style={{
-          color: 'white',
-        }}
-      >
-        layer-blur and drop-shadow
       </RadiusAutoLayout>
     </RadiusAutoLayout>
   ),

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -556,51 +556,68 @@ export const ClippedContent: Story = {
   ),
 };
 
-export const Absolute: Story = {
-  render: () => (
+/**
+ * The `absolutePosition` property controls whether the Auto Layout component
+ * is positioned absolutely or not. This is equivalent to `position: absolute`
+ * in CSS. In this mode, the `x` and `y` properties control the position of the
+ * Auto Layout component, with `x` representing the distance from the left, and
+ * `y` representing the distance from the top. It is important that the parent
+ * has the `isParent` property set to `true` so that the Auto Layout component
+ * can be positioned relative to its parent. Otherwise, it will be positioned
+ * relative to the viewport.
+ *
+ * [How Figma Absolute Positioning Works](https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties#h_01G2RPRBBKVKXK0JV59NCSKEE0)
+ */
+export const AbsolutePosition: Story = {
+  parameters: {
+    controls: {
+      // only show controls relevant to this story
+      include: ['x', 'y'],
+    },
+  },
+  args: {
+    x: '157px',
+    y: '82px',
+  },
+  // @ts-expect-error - bug with `args` type inference due to polymorphism
+  render: ({ x, y }: AutoLayoutExtendedProps) => (
     <RadiusAutoLayout
-      direction={'vertical'}
-      width={'fill-parent'}
-      strokeAlign={'inside'}
-      stroke={{ css: 'black' }}
-      padding={{ css: '20px' }}
-      isParent={true}
-      height={200}
-      style={{ fontFamily: 'Riforma LL' }}
+      stroke={{ css: '#006C95' }}
+      strokeWidth={{ css: '3px' }}
+      cornerRadius={{ css: '12px' }}
+      padding={{ css: '24px' }}
+      space="auto"
+      width={630}
+      isParent
     >
+      <RadiusAutoLayout width={40} height={242} fill={{ css: '#F7856E' }} />
+      <RadiusAutoLayout width={40} height={242} fill={{ css: '#F7856E' }} />
+      <RadiusAutoLayout width={40} height={242} fill={{ css: '#F7856E' }} />
       <RadiusAutoLayout
-        fill={{ css: 'black' }}
+        fill={{ css: '#D44527' }}
+        height={100}
+        width={383}
+        alignment="center"
         style={{
-          color: 'white',
+          justifyContent: 'center', // only needed until alignment changes are merged
         }}
-        padding={{ css: '12px' }}
-        absolutePosition={true}
-        x="0%"
-        y="0%"
+        padding={{ css: '20px' }}
+        absolutePosition
+        x={x}
+        y={y}
       >
-        Top Left
-      </RadiusAutoLayout>
-      <RadiusAutoLayout
-        padding={{ css: '12px' }}
-        fill={{ css: 'black' }}
-        style={{
-          color: 'white',
-        }}
-        horizontalConstraint="right"
-        verticalConstraint="bottom"
-        absolutePosition={true}
-        x={0}
-        y="0px"
-      >
-        Bottom Right
+        <span
+          style={{
+            color: 'white',
+            fontFamily: 'Riforma LL',
+            fontSize: '16px',
+          }}
+        >
+          Element positioned absolutely
+        </span>
       </RadiusAutoLayout>
     </RadiusAutoLayout>
   ),
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
 };
 
 export const AsElements: Story = {

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -417,42 +417,64 @@ export const StrokeAndStrokeWidth: Story = {
   ),
 };
 
-export const BorderRadius: Story = {
-  render: () => (
-    <RadiusAutoLayout
-      direction={'horizontal'}
-      alignment={'top'}
-      width={'fill-parent'}
-      padding={{ css: '12px' }}
-    >
+/**
+ * The `cornerRadius` property controls the radius of the corners. `cornerRadius`
+ * can be a single value or a list of values. If a list of values is provided,
+ * the values are applied in the following order: top-left, top-right,
+ * bottom-right, bottom-left.
+ */
+export const CornerRadius: Story = {
+  parameters: {
+    controls: {
+      // only show controls relevant to this story
+      include: ['cornerRadius'],
+    },
+  },
+  argTypes: {
+    cornerRadius: {
+      options: {
+        '0px': { css: '0px' },
+        '5px': { css: '5px' },
+        '20px': { css: '20px' },
+        '50px': { css: '50px' },
+        '50%': { css: '50%' },
+        '10px 20px 30px 40px': { css: '10px 20px 30px 40px' },
+      },
+    },
+  },
+  // @ts-expect-error - bug with `args` type inference due to polymorphism
+  render: ({ cornerRadius }: AutoLayoutExtendedProps) => (
+    <RadiusAutoLayout>
       <RadiusAutoLayout
-        width={50}
-        height={50}
-        // @ts-expect-error - cornerRadius type needs refinement
-        cornerRadius={radiusTokens.core.borderRadius[4]}
-        stroke={{ css: '#D44527' }}
+        width={200}
+        height={200}
+        stroke={{ css: '#006C95' }}
+        strokeWidth={{ css: '3px' }}
+        cornerRadius={cornerRadius ?? { css: '5px' }}
       />
       <RadiusAutoLayout
-        width={50}
-        height={50}
-        // @ts-expect-error - cornerRadius type needs refinement
-        cornerRadius={radiusTokens.core.borderRadius[16]}
-        stroke={{ css: '#D44527' }}
+        width={200}
+        height={200}
+        stroke={{ css: '#006C95' }}
+        strokeWidth={{ css: '3px' }}
+        cornerRadius={cornerRadius ?? { css: '20px' }}
       />
       <RadiusAutoLayout
-        width={50}
-        height={50}
-        // @ts-expect-error - cornerRadius type needs refinement
-        cornerRadius={radiusTokens.core.borderRadius.max}
-        stroke={{ css: '#D44527' }}
+        width={200}
+        height={200}
+        stroke={{ css: '#006C95' }}
+        strokeWidth={{ css: '3px' }}
+        cornerRadius={cornerRadius ?? { css: '50px' }}
+      />
+      <RadiusAutoLayout
+        width={200}
+        height={200}
+        stroke={{ css: '#006C95' }}
+        strokeWidth={{ css: '3px' }}
+        cornerRadius={cornerRadius ?? { css: '50%' }}
       />
     </RadiusAutoLayout>
   ),
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
 };
 
 export const Absolute: Story = {

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -355,43 +355,66 @@ export const Fill: Story = {
   },
 };
 
-export const Border: Story = {
-  render: () => (
-    <RadiusAutoLayout
-      direction="horizontal"
-      alignment="top"
-      width="fill-parent"
-      padding={{ css: '12px' }}
-    >
+/**
+ * The `stroke` property controls the color of the border. The `strokeWidth`
+ * property controls the thickness of the border. `strokeWidth` can be a single
+ * value or a list of values. If a list of values is provided, the values are
+ * applied in the following order: top, right, bottom, left.
+ */
+export const StrokeAndStrokeWidth: Story = {
+  parameters: {
+    controls: {
+      // only show controls relevant to this story
+      include: ['stroke', 'strokeWidth'],
+    },
+  },
+  argTypes: {
+    stroke: {
+      options: {
+        black: { css: 'black' },
+        red: { css: 'red' },
+        blue: { css: 'blue' },
+        green: { css: 'green' },
+      },
+    },
+    strokeWidth: {
+      options: {
+        '1px': { css: '1px' },
+        '3px': { css: '3px' },
+        '2px 15px': { css: '2px 15px' },
+        '5px 10px 15px 20px': { css: '5px 10px 15px 20px' },
+      },
+    },
+  },
+  // @ts-expect-error - bug with `args` type inference due to polymorphism
+  render: ({ stroke, strokeWidth }: AutoLayoutExtendedProps) => (
+    <RadiusAutoLayout>
       <RadiusAutoLayout
-        width={50}
-        height={50}
-        stroke={{ css: '#D44527' }}
-        // @ts-expect-error - strokeWidth type needs refinement
-        strokeWidth={radiusTokens.core.borderWidth['1']}
+        width={200}
+        height={200}
+        stroke={stroke ?? { css: '#006C95' }}
+        strokeWidth={strokeWidth ?? { css: '1px' }}
       />
       <RadiusAutoLayout
-        width={50}
-        height={50}
-        stroke={{ css: '#D44527' }}
-        strokeAlign="outside"
-        // @ts-expect-error - strokeWidth type needs refinement
-        strokeWidth={radiusTokens.core.borderWidth['2']}
+        width={200}
+        height={200}
+        stroke={stroke ?? { css: '#006C95' }}
+        strokeWidth={strokeWidth ?? { css: '3px' }}
       />
       <RadiusAutoLayout
-        width={50}
-        height={50}
-        stroke={{ css: '#D44527' }}
-        strokeAlign="inside"
-        strokeWidth={{ css: '20px 0 1px 5px' }}
+        width={200}
+        height={200}
+        stroke={stroke ?? { css: '#006C95' }}
+        strokeWidth={strokeWidth ?? { css: '5px' }}
+      />
+      <RadiusAutoLayout
+        width={200}
+        height={200}
+        stroke={stroke ?? { css: '#006C95' }}
+        strokeWidth={strokeWidth ?? { css: '7px' }}
       />
     </RadiusAutoLayout>
   ),
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
 };
 
 export const BorderRadius: Story = {

--- a/library/core-components/components/auto-layout/auto-layout.stories.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { radiusTokens } from '@rangle/radius-foundations/generated/design-tokens.constants';
 
 import { BADGE } from '@geometricpanda/storybook-addon-badges';
+import { Typography } from '../typography/typography';
 import { RadiusAutoLayout } from './auto-layout';
 import { RadiusButton } from '../button/button';
 import { flattenObject } from '../../utils';
@@ -842,15 +843,34 @@ export const Effects: Story = {
   },
 };
 
-export const Layouts: Story = {
+/**
+ * Most of the props of RadiusAutoLayout support tokens. Tokens are a way to
+ * reference a value from a design system (like Radius). This means that values
+ * defined by designers in Figma can be used directly in code, ensuring that
+ * the design and code are always in sync, eliminating communication errors, and
+ * greatly simplifying the development process.
+ *
+ * Tokens are even able to represent styles across multiple themes and
+ * breakpoints. As you can see in the example below, the layout is fully responsive
+ * across breakpoints, and the colors and typography change based on the theme,
+ * all without any CSS. This is possible because the tokens are defined in a way
+ * that allows them to be responsive and themeable in Figma using Tokens Studio,
+ * and those values are converted directly into CSS variables in the appropriate
+ * contexts/layers.
+ *
+ * Keep an eye out for  our upcoming explainer video on how to create your own
+ * dynamic and responsive components using tokens!
+ */
+export const TokenizedLayout: Story = {
   render: () => (
     <RadiusAutoLayout
       width="fill-parent"
-      space={{ css: '20px' }}
+      space={radiusTokens.component.spacing.hero.gap.image}
+      direction={radiusTokens.component.direction.hero.contentContainer}
+      fill={radiusTokens.component.color.hero.background}
       alignment="center"
-      isParent={true}
+      isParent
       style={{
-        color: `var(${{ css: 'black' }})`,
         fontFamily: 'Riforma LL',
       }}
     >
@@ -862,20 +882,25 @@ export const Layouts: Story = {
           width="fill-parent"
         />
       </RadiusAutoLayout>
-      <RadiusAutoLayout width="fill-parent" direction="vertical">
-        <RadiusAutoLayout
-          as={RadiusButton}
-          variant="primary"
-          absolutePosition={true}
-          x={0}
-          y={0}
-          verticalConstraint="top"
-          horizontalConstraint="right"
+      <RadiusAutoLayout
+        width="fill-parent"
+        direction={radiusTokens.component.direction.hero.textContainer.outer}
+        space={radiusTokens.component.spacing.hero.gap.aboveButton}
+      >
+        <Typography
+          as="h1"
+          font={radiusTokens.component.typography.hero.header.font}
+          fill={radiusTokens.component.color.hero.header}
         >
-          Close Button
-        </RadiusAutoLayout>
-        <RadiusAutoLayout as="h2">Hello world</RadiusAutoLayout>
-        <RadiusAutoLayout as="p">As paragraph</RadiusAutoLayout>
+          Hello World
+        </Typography>
+        <Typography
+          as="p"
+          font={radiusTokens.component.typography.hero.eyebrow.font}
+          fill={radiusTokens.component.color.hero.eyebrow}
+        >
+          I am fully responsive and themeable without any CSS
+        </Typography>
       </RadiusAutoLayout>
     </RadiusAutoLayout>
   ),

--- a/library/core-components/components/auto-layout/auto-layout.tsx
+++ b/library/core-components/components/auto-layout/auto-layout.tsx
@@ -26,6 +26,8 @@ import { useStyles } from './auto-layout.styles';
  *
  * ### Resources
  * [Explore Auto Layout properties](https://help.figma.com/hc/en-us/articles/360040451373-Explore-auto-layout-properties)
+ *
+ * [RadiusAutoLayout Figma Specs](https://www.figma.com/file/ODAUZaQxH8oH2GI0A9MAVb/Radius-Booster---Auto-Layout?type=design&node-id=1302-3734)
  * */
 export const RadiusAutoLayout: AutoLayoutComponent = forwardRef(
   <C extends React.ElementType = 'div'>(

--- a/library/core-components/components/auto-layout/auto-layout.types.ts
+++ b/library/core-components/components/auto-layout/auto-layout.types.ts
@@ -46,18 +46,25 @@ export type StrokeCap =
   | 'arrow-lines'
   | 'arrow-equilateral';
 
-export type HorizontalConstraint =
-  | 'left'
-  | 'right'
-  | 'left and right'
-  | 'center'
-  | 'scale';
-export type VerticalConstraint =
-  | 'top'
-  | 'bottom'
-  | 'top and bottom'
-  | 'center'
-  | 'scale';
+/**
+ * The horizontal constraint to use when absolutely positioning an item.
+ * Note that we are currently missing some functionality from Figma (`left and
+ * right`, `center`, and `scale`)
+ * */
+export type HorizontalConstraint = 'left' | 'right';
+// | 'left and right'
+// | 'center'
+// | 'scale';
+
+/**
+ * The vertical constraint to use when absolutely positioning an item.
+ * Note that we are currently missing some functionality from Figma (`top and
+ * bottom`, `center`, and `scale`)
+ * */
+export type VerticalConstraint = 'top' | 'bottom';
+// | 'top and bottom'
+// | 'center'
+// | 'scale';
 
 export type AutoLayoutExtendedProps = {
   /** Used in conjunction with absolutePosition, uses and sets position: 'relative' */

--- a/library/core-components/components/button/button.stories.tsx
+++ b/library/core-components/components/button/button.stories.tsx
@@ -13,10 +13,6 @@ const meta: Meta<typeof RadiusButton> = {
   component: RadiusButton,
   title: 'Radius Examples / Button',
   parameters: {
-    design: {
-      type: 'figma',
-      url: 'https://www.figma.com/file/????',
-    },
     // Version is rendered by this plugin https://github.com/silversonicaxel/storybook-addon-versioning
     version: {
       major: process.env.COMPONENT_VERSION?.[0],

--- a/library/core-components/components/footer/footer.stories.tsx
+++ b/library/core-components/components/footer/footer.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof RadiusFooter> = {
   component: RadiusFooter,
   title: 'Radius Examples / Footer',
   parameters: {
-    badges: [BADGE.EXPERIMENTAL],
+    badges: [BADGE.BETA],
   },
   argTypes: {
     as: {

--- a/library/core-components/components/image-text-item/image-text-item.stories.tsx
+++ b/library/core-components/components/image-text-item/image-text-item.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<RadiusImageTextItemProps> = {
   component: RadiusImageTextItem,
   title: 'Radius Examples / ImageTextItem',
   parameters: {
-    badges: [BADGE.EXPERIMENTAL],
+    badges: [BADGE.BETA],
   },
   argTypes: {
     className: {

--- a/library/core-components/components/image-text-list/image-text-list.stories.tsx
+++ b/library/core-components/components/image-text-list/image-text-list.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<RadiusImageTextListProps> = {
   component: RadiusImageTextList,
   title: 'Radius Examples / ImageTextList',
   parameters: {
-    badges: [BADGE.EXPERIMENTAL],
+    badges: [BADGE.BETA],
     controls: {
       disable: true,
     },

--- a/library/core-components/components/link-button/link-button.stories.tsx
+++ b/library/core-components/components/link-button/link-button.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof RadiusLinkButton> = {
   component: RadiusLinkButton,
   title: 'Radius Examples / Link Button',
   parameters: {
-    badges: [BADGE.EXPERIMENTAL],
+    badges: [BADGE.BETA],
   },
   argTypes: {
     as: {

--- a/library/core-components/components/nav-item/nav-item.stories.tsx
+++ b/library/core-components/components/nav-item/nav-item.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta<typeof RadiusNavItem> = {
   component: RadiusNavItem,
   title: 'Radius Examples / Nav Item',
   parameters: {
-    badges: [BADGE.EXPERIMENTAL],
+    badges: [BADGE.BETA],
   },
   argTypes: {
     as: {

--- a/library/core-components/components/nav/nav.stories.tsx
+++ b/library/core-components/components/nav/nav.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta<typeof RadiusNav> = {
   component: RadiusNav,
   title: 'Radius Examples / Nav',
   parameters: {
-    badges: [BADGE.EXPERIMENTAL],
+    badges: [BADGE.BETA],
   },
   argTypes: {
     as: {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@storybook/addon-essentials": "^7.0.12",
     "@storybook/addon-interactions": "^7.0.12",
     "@storybook/addon-links": "^7.0.12",
-    "@storybook/addon-mdx-gfm": "^7.0.12",
     "@storybook/cli": "^7.0.12",
     "@storybook/react": "^7.0.12",
     "@storybook/react-webpack5": "^7.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5766,12 +5766,12 @@
   dependencies:
     nx "15.9.2"
 
-"@nrwl/cypress@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-Wz53YI9E5YtdYgoVw0hfB/cEU7b2befl4TvoQTP3jqSTrneXBXxVGfPXl2E0/dqY3sOErzi78qhkN8hxBl825w==
+"@nrwl/cypress@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nrwl/cypress/-/cypress-16.3.2.tgz#a9bf8b5a211b5c69df4065c9142ae17c91af4ab2"
+  integrity sha512-f1RWC4jFe0KNDKRs8FY8gn2ik0+DOGsw/HG2oz5Ck/sT1yPwexLZ/+I854UuKs2Gtw5/B/l/7hcis+/MsgXe2Q==
   dependencies:
-    "@nx/cypress" "16.2.1"
+    "@nx/cypress" "16.3.2"
 
 "@nrwl/devkit@15.9.2":
   version "15.9.2"
@@ -5784,12 +5784,12 @@
     tmp "~0.2.1"
     tslib "^2.3.0"
 
-"@nrwl/devkit@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-yeNEccQzDuL+/thbS2XTq8MtD0KDrI92gXIPSrS/Q6QnDNJGz6T2kRe/mJWrcfrDFm/L61MsAlGXobElhceNMw==
+"@nrwl/devkit@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nrwl/devkit/-/devkit-16.3.2.tgz#b45393dfd62dcb75554ff0c2dff6715a907e3877"
+  integrity sha512-EiDwVIvh6AcClXv22Q7auQh7Iy/ONISEFWzTswy/J6ZmVGCQesbiwg4cGV0MKiScr+awdVzqyNey+wD6IR5Lkw==
   dependencies:
-    "@nx/devkit" "16.2.1"
+    "@nx/devkit" "16.3.2"
 
 "@nrwl/devkit@>=15.4.2 < 16":
   version "15.6.3"
@@ -5849,12 +5849,12 @@
     tree-kill "1.2.2"
     tslib "^2.3.0"
 
-"@nrwl/js@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-+XCgHocQzqn/wQauzTuWv/ioyuuiC3FfE3H+wg2FgfYuJLYuGyGx4qDhuiGvaaLqOK1dJQxLBsZW9Gjk77qe1g==
+"@nrwl/js@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nrwl/js/-/js-16.3.2.tgz#60268ebbb08a82ea3c1ce29b89a58bfbb96ccddd"
+  integrity sha512-UMmdA4vXy2/VWNMlpBDruT9XwGmLw/MpUaKoN2KLkai/fYN6MvB3mabc9WQ8qsNvDWshmOJ6TqAHReR25BjugQ==
   dependencies:
-    "@nx/js" "16.2.1"
+    "@nx/js" "16.3.2"
 
 "@nrwl/linter@15.9.2":
   version "15.9.2"
@@ -5867,12 +5867,12 @@
     tmp "~0.2.1"
     tslib "^2.3.0"
 
-"@nrwl/linter@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-lICc3UUURJ3NuXJNSWLf/Rbff/GKpxiCkW/k8XlHfQRmWVMUS0Xvzk0NIxQTQO4WRCtX5wmYmfYTehCyS5xqKg==
+"@nrwl/linter@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nrwl/linter/-/linter-16.3.2.tgz#b99eabfceab16dc404415d0d87fa3e380b6f859f"
+  integrity sha512-sUDQNlmRIGQnhdDmpQkJgpF9LZWKBoqXr2g9Y4yq0QlpTamxTbx8/GxMICotA52kayEx1cKbU1xvjJWPchSrlw==
   dependencies:
-    "@nx/linter" "16.2.1"
+    "@nx/linter" "16.3.2"
 
 "@nrwl/nx-cloud@^15.3.5":
   version "15.3.5"
@@ -5948,12 +5948,12 @@
     file-loader "^6.2.0"
     minimatch "3.0.5"
 
-"@nrwl/storybook@16.2.1", "@nrwl/storybook@^16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-AgAZPH/ePcpzQRgbnDLDcYhpUM2pA5Gs7R5tWMIQ6hEbi9/mOCpBwq8YSk4i+6bTB8TCCjE4ph0H63fzHkJgwQ==
+"@nrwl/storybook@16.3.2", "@nrwl/storybook@^16.2.1":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nrwl/storybook/-/storybook-16.3.2.tgz#0f09e3d23535aea5e78a4f285d215317f005881b"
+  integrity sha512-luANnl0Hd3FxRfrOvB+GxgAlcm6vPuaAVvcrycD32+nFY85bivNhkJg5wcVBkOhFyQAgJD1yQAi4HJm7ar9EOA==
   dependencies:
-    "@nx/storybook" "16.2.1"
+    "@nx/storybook" "16.3.2"
 
 "@nrwl/tao@15.6.3":
   version "15.6.3"
@@ -5969,12 +5969,12 @@
   dependencies:
     nx "15.9.2"
 
-"@nrwl/tao@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-mhLkMxGFbnR4hu9UbjMvzdePDXmUpV33mImt1myewP/cY9YZdzv5ntqT+9U+zzVg7Q2ZGosiGQE+IYRm6yeWog==
+"@nrwl/tao@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nrwl/tao/-/tao-16.3.2.tgz#eefc1974342afbbe48e4e5351d6707ad2f9fb179"
+  integrity sha512-2Kg7dtv6JcQagCZPSq+okceI81NqmXGGgbKWqS7sOfdmp1otxS9uiUFNXw+Pdtnw38mdRviMtSOXScntu4sUKg==
   dependencies:
-    nx "16.2.1"
+    nx "16.3.2"
 
 "@nrwl/web@^15.9.2":
   version "15.9.2"
@@ -6016,43 +6016,43 @@
     yargs "^17.6.2"
     yargs-parser "21.1.1"
 
-"@nrwl/workspace@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-k9CUsGNBC5gTnTMcPDHFkxIPzzhhm47DhmNV3xueuwSAyZbvnekCtmkFRdwe4jtOFjB6+MpTsol9p37vKfXVLA==
+"@nrwl/workspace@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nrwl/workspace/-/workspace-16.3.2.tgz#3d3921dc9288fb6a9dfd8f1b05ca16b46930cdac"
+  integrity sha512-ORVzEEJIMOFYEOtOQHLU7N4vT4mYZ/JzKiwHZrHkCaVhgkiGBLoX3tOwVZjafKaa/24cGISv0J7WRtnfRKl2cA==
   dependencies:
-    "@nx/workspace" "16.2.1"
+    "@nx/workspace" "16.3.2"
 
-"@nx/cypress@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-e5lZMlj/qcv5N59Mr8nPTTFfQvPuWGwyCvSt8gmTqCiszRwt72Jsl6OEM7cVYE8rCWlSuBnBrafs1bqOt+Fxkg==
+"@nx/cypress@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nx/cypress/-/cypress-16.3.2.tgz#1e248a0237597ba84cc1bf9465ff0b4bbc11c8ae"
+  integrity sha512-XB4CvhTv154GHp/2+lSoCigPKZK1YoRyIZWIHJdBmpQUocLJkSqp+H8KQaU/0gH3Xbz5NxGXbQMFDWzkKxIGPg==
   dependencies:
-    "@nrwl/cypress" "16.2.1"
-    "@nx/devkit" "16.2.1"
-    "@nx/js" "16.2.1"
-    "@nx/linter" "16.2.1"
+    "@nrwl/cypress" "16.3.2"
+    "@nx/devkit" "16.3.2"
+    "@nx/js" "16.3.2"
+    "@nx/linter" "16.3.2"
     "@phenomnomnominal/tsquery" "~5.0.1"
     detect-port "^1.5.1"
     dotenv "~10.0.0"
     semver "7.3.4"
 
-"@nx/devkit@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-OrnFkU+lrSP/MdQW6C07aMlLyMp98oZMyfZ6h721T66zvuDfchhG2RXLX/Rb2t1lgZ+oMBKwvxxUKMRpHKPekA==
+"@nx/devkit@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nx/devkit/-/devkit-16.3.2.tgz#95d58d104449c54bdc276fa1c9166fcad867cfa8"
+  integrity sha512-1ev3EDm2Sx/ibziZroL1SheqxDR7UgC49tkBgJz1GrQLQnfdhBYroCPSyBSWGPMLHjIuHb3+hyGSV1Bz+BIYOA==
   dependencies:
-    "@nrwl/devkit" "16.2.1"
+    "@nrwl/devkit" "16.3.2"
     ejs "^3.1.7"
     ignore "^5.0.4"
     semver "7.3.4"
     tmp "~0.2.1"
     tslib "^2.3.0"
 
-"@nx/js@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-WpK8yqVCrkCRTbNxSuRuQFpBXyX+doynixVv8yuB8HKPfE/wx6252eUMT43DWQJ+stmd5IhoH4THGyqpf+aaHg==
+"@nx/js@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nx/js/-/js-16.3.2.tgz#1f2e6807439bfb525f24f983558e7b054d57c3f2"
+  integrity sha512-bumLGMduNm221Sh3/wkEMEkJOC1kTlqmpx6wamDSsPlAFq0ePgoaNJjoYqC9XH7n7wXtgy9bgKhHJPnek8NKow==
   dependencies:
     "@babel/core" "^7.15.0"
     "@babel/plugin-proposal-class-properties" "^7.14.5"
@@ -6061,9 +6061,9 @@
     "@babel/preset-env" "^7.15.0"
     "@babel/preset-typescript" "^7.15.0"
     "@babel/runtime" "^7.14.8"
-    "@nrwl/js" "16.2.1"
-    "@nx/devkit" "16.2.1"
-    "@nx/workspace" "16.2.1"
+    "@nrwl/js" "16.3.2"
+    "@nx/devkit" "16.3.2"
+    "@nx/workspace" "16.3.2"
     "@phenomnomnominal/tsquery" "~5.0.1"
     babel-plugin-const-enum "^1.0.1"
     babel-plugin-macros "^2.8.0"
@@ -6074,89 +6074,94 @@
     ignore "^5.0.4"
     js-tokens "^4.0.0"
     minimatch "3.0.5"
+    semver "7.3.4"
     source-map-support "0.5.19"
     tslib "^2.3.0"
 
-"@nx/linter@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-YxIueiJbFkd1Xtno9RbSFXp1J78Fb21N3C0jzPl0K+hHXivAZVfOAx+btYMxPZoGqW7USVeQKaCnoj9jitHo3A==
+"@nx/linter@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nx/linter/-/linter-16.3.2.tgz#85411007f9d64f2723f532735f96d1a17480e2e1"
+  integrity sha512-hVCU6ZIMd+yTMLrC3PbjaHuD3yU+sB/lABTaWuUx2klT0cqKhiTp0KnDLcFWtzQmnNtGEaUjfPKxvA92xon0CA==
   dependencies:
-    "@nrwl/linter" "16.2.1"
-    "@nx/devkit" "16.2.1"
-    "@nx/js" "16.2.1"
+    "@nrwl/linter" "16.3.2"
+    "@nx/devkit" "16.3.2"
+    "@nx/js" "16.3.2"
     "@phenomnomnominal/tsquery" "~5.0.1"
     tmp "~0.2.1"
     tslib "^2.3.0"
 
-"@nx/nx-darwin-arm64@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-xK/dL5T2R8zrcD8/13PeaYH/LBcYeaELIZkXGdGbtQ8WeFHjPJLBfuWo/7Se7KSWIXLIJEeYrVZwyxuei1dOTA==
+"@nx/nx-darwin-arm64@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.3.2.tgz#83b6e78b27d2d7da8f7626560f52070c8735d28a"
+  integrity sha512-YfYVNfsJBzBcBnJUU4AcA6A4QMkgnVlETfp4KGL36Otq542mRY1ISGHdox63ocI5AKh5gay5AaGcR4wR9PU9Vg==
 
-"@nx/nx-darwin-x64@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-J1ZBqy8FtIhvZopcc96JWZY2InZClQ+XHWHnAmX8S1f79hcLUiatpu90FZhvfXmfOfLlpkKsa8aje/kjpnnWhA==
+"@nx/nx-darwin-x64@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nx/nx-darwin-x64/-/nx-darwin-x64-16.3.2.tgz#0ae2a64356542c5fb73ca8038ce10ec4512e7fcb"
+  integrity sha512-bJtpozz0zSRVRrcQ76GrlT3TWEGTymLYWrVG51bH5KZ46t6/a4EQBI3uL3vubMmOZ0jR4ywybOcPBBhxmBJ68w==
 
-"@nx/nx-linux-arm-gnueabihf@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-rnujPmWlnkEvzkWARuW85cizVx6uGwQ/gA84tK3cHZQf9ly172WbDtsMtYRS9/CjvysMqDV0zBd7o/YhwpXNZg==
+"@nx/nx-freebsd-x64@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nx/nx-freebsd-x64/-/nx-freebsd-x64-16.3.2.tgz#202adf4d6070f47ed46450f006ecd50851147c74"
+  integrity sha512-ZvufI0bWqT67nLbBo6ejrIGxypdoedRQTP/tudWbs/4isvxLe1uVku1BfKCTQUsJG367SqNOU1H5kzI/MRr3ow==
 
-"@nx/nx-linux-arm64-gnu@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-ZcuQN8eaxEI+93ut6UrDrZMPsk61LGlS6yaWPgrv3blKMfcU2+DYBDQ3ois7o5t0bnVad5QYSNhIvnMF2iU+hQ==
+"@nx/nx-linux-arm-gnueabihf@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.3.2.tgz#62314a82566e3647866b9dd4167a2d0e1397f001"
+  integrity sha512-IQL4kxdiZLvifar7+SIum3glRuVsxtE0dL8RvteSDXrxDQnaTUrjILC+VGhalRmk7ngBbGKNrhWOeeL7390CzQ==
 
-"@nx/nx-linux-arm64-musl@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-mMOvkYyBLU4j+mSHobtrj/pIDYXFGIX3Q9FMWxZ5Xz15m0DsbypZ/8v6NWpJaBY4VX6rJhCc+D/pZH+QBT8+/g==
+"@nx/nx-linux-arm64-gnu@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.3.2.tgz#02826400aa55b8f44bac83332dd29647d0e95001"
+  integrity sha512-f6AWgPVu3mfUEoOBa0rY2/7QY0Or9eR0KtLFpcPh7RUpxPw2EXzIbjD/0RGipdpspSrgiMKbZpsUjo6mXBFsQA==
 
-"@nx/nx-linux-x64-gnu@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-Kyn4dxFTj2PCRv+39tKU8BzDRE6/ru5v435uvodx03GS650F7+OMr4DN57jG4MQWhf//OUX8zPkvbKhsmxjndA==
+"@nx/nx-linux-arm64-musl@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.3.2.tgz#a0a81520e0904aa026a7ab0a8a3bf3facec9f14c"
+  integrity sha512-AvrWcYz7021E3b5P9/0i26p60XMZfw86Epks51L6AhlflarlOH4AcEChc7APMtb1ELAIbDWx2S6oIDRbQ7rtVA==
 
-"@nx/nx-linux-x64-musl@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-q8iFxLosSLiWkRWsbrioXV/qMG8TgsbqcM0VGz2FFLNMJ9DXvav/E/+8YbgEeHOjvA1MDeRaspIpDF7OMgJYGw==
+"@nx/nx-linux-x64-gnu@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.3.2.tgz#e79b5c142ec8d9bfb458ea5803bc4b62abbcf296"
+  integrity sha512-K2pWGAcbCNm6b7UZI9cc8z4Rb540QcuepBXD7akjPjWerzXriT6VCn4i9mVKsCg2mwSfknTJJVJ1PZwJSmTl/Q==
 
-"@nx/nx-win32-arm64-msvc@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-PpGiYzrMivDY1i10Zwf5Hmnv6oAQ8ACf6ehDgyQ3tByMMXHgyUZJLykfPaoWjoLh0s8wOvMV74WZO+K1LcIxTA==
+"@nx/nx-linux-x64-musl@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.3.2.tgz#900aee8f171638b9fb44378e2ac0548cb4aa99a7"
+  integrity sha512-sY1QDuQlqyYiRPJZanrtV07tU0DOXiCrWb0pDsGiO0qHuUSmW5Vw17GWEY4z3rt0/5U8fJ+/9WQrneviOmsOKg==
 
-"@nx/nx-win32-x64-msvc@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-m5oHCaSKdyydM1n1W9V0m2oxBL8PiF54dZB0+PlKB2fhf1zxiyq8i1hL2hXbKA90IOYcUt5/b7761/BzN5njAw==
+"@nx/nx-win32-arm64-msvc@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.3.2.tgz#88db772b3535648e147b1a0206b1a1fe875fa9a5"
+  integrity sha512-wBfohT2hjrLKn9WFHvG0MFVk7uYhgYNiptnTLdTouziHgFyZ08vyl7XYBq55BwHPMQ5iswVoEfjn/5ZBfCPscg==
 
-"@nx/storybook@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-674QYgb+CQX9QdSwSbPkaI25vA1n+MLS+t1MHbAvkfvG5d9RiwWm79c0iBRz+EkYD8wV0xIJfO4mfIDE3m5ztA==
+"@nx/nx-win32-x64-msvc@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.3.2.tgz#2195faaf1fc465c7a89bfdd62323fdd2a5d91f15"
+  integrity sha512-QC0sWrfQm0/WdvvM//7UAgm+otbak6bznZ0zawTeqmLBh1hLjNeweyzSVKQEtZtlzDMKpzCVuuwkJq+VKBLvmw==
+
+"@nx/storybook@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nx/storybook/-/storybook-16.3.2.tgz#607a3b2ca3bca4af29734ef9c9a24ac32c1242bb"
+  integrity sha512-5iBStqDWHIRI405RBqeiiGHTJARU0WeWFQYxO8sViv7oYRcEpTYQk+w+aAUIS5hzxQmUjXTX7RcoeOtiymVgSQ==
   dependencies:
-    "@nrwl/storybook" "16.2.1"
-    "@nx/cypress" "16.2.1"
-    "@nx/devkit" "16.2.1"
-    "@nx/js" "16.2.1"
-    "@nx/linter" "16.2.1"
-    "@nx/workspace" "16.2.1"
+    "@nrwl/storybook" "16.3.2"
+    "@nx/cypress" "16.3.2"
+    "@nx/devkit" "16.3.2"
+    "@nx/js" "16.3.2"
+    "@nx/linter" "16.3.2"
+    "@nx/workspace" "16.3.2"
     "@phenomnomnominal/tsquery" "~5.0.1"
     dotenv "~10.0.0"
-    enquirer "~2.3.6"
     semver "7.3.4"
 
-"@nx/workspace@16.2.1":
-  version "16.2.1"
-  
-  integrity sha512-gGJNKsH2KFtxlBBL0AqPu0vo322wGfCPDK19OxgwTQMWDruMZ9jjAe3XU4a+FbCGmK1CmZUlbFo4HueD9hVkig==
+"@nx/workspace@16.3.2":
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/@nx/workspace/-/workspace-16.3.2.tgz#145d4ee7b909d5b430d7ac9a8043d688a00d017c"
+  integrity sha512-gFrJEv3+Jn2leu3RKFTakPHY8okI8hjOg8RO4OWA2ZemFXRyh9oIm/xsCsOyqYlGt06eqV2mD3GUun/05z1nhg==
   dependencies:
-    "@nrwl/workspace" "16.2.1"
-    "@nx/devkit" "16.2.1"
+    "@nrwl/workspace" "16.3.2"
+    "@nx/devkit" "16.3.2"
     "@parcel/watcher" "2.0.4"
     chalk "^4.1.0"
     chokidar "^3.5.1"
@@ -6168,7 +6173,7 @@
     ignore "^5.0.4"
     minimatch "3.0.5"
     npm-run-path "^4.0.1"
-    nx "16.2.1"
+    nx "16.3.2"
     open "^8.4.0"
     rxjs "^7.8.0"
     tmp "~0.2.1"
@@ -6299,7 +6304,7 @@
 
 "@phenomnomnominal/tsquery@~5.0.1":
   version "5.0.1"
-  
+  resolved "https://registry.yarnpkg.com/@phenomnomnominal/tsquery/-/tsquery-5.0.1.tgz#a2a5abc89f92c01562a32806655817516653a388"
   integrity sha512-3nVv+e2FQwsW8Aw6qTU6f+1rfcJ3hrcnvH/mu9i8YhxO+9sqbOfpL8m6PbET5+xKOlz/VSbp0RoYWYCtIsnmuA==
   dependencies:
     esquery "^1.4.0"
@@ -6660,19 +6665,19 @@
     lodash.union "^4.6.0"
     lodash.values "^4.3.0"
 
-"@storybook/addon-actions@7.0.12", "@storybook/addon-actions@^7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-f07Mc3qwcG9heGsuUUTIJbWF2nw/Ite3mvyIZY2VbgwhMUMVHj4knY4fh/LojwcUmmmc7CNZu3sJN/wIqpaHCQ==
+"@storybook/addon-actions@7.0.18", "@storybook/addon-actions@^7.0.12":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-7.0.18.tgz#003cb5fc7810b5ba9fd2c8249ba82bc4b95a02dc"
+  integrity sha512-3M5AU/ZD79YP88vKlFezIJbIoG/II7wCixUBTmwiC3BeQZDuVsqPNl8eiP6MGT70xwyx7a993lSM5f5N5W93vg==
   dependencies:
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/components" "7.0.12"
-    "@storybook/core-events" "7.0.12"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/components" "7.0.18"
+    "@storybook/core-events" "7.0.18"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
-    "@storybook/theming" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/manager-api" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
+    "@storybook/theming" "7.0.18"
+    "@storybook/types" "7.0.18"
     dequal "^2.0.2"
     lodash "^4.17.21"
     polished "^4.2.2"
@@ -6682,189 +6687,180 @@
     ts-dedent "^2.0.0"
     uuid "^9.0.0"
 
-"@storybook/addon-backgrounds@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-sAZSxsbj3CcabowALKTafpdnqXMBZB8C42s4Uxv11FCP50GqrP8jp2TqsIiDZxUbeXwI094W/gHnw41MSphG8Q==
+"@storybook/addon-backgrounds@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-7.0.18.tgz#ffb47f8ac5e51718103b8931326321032d0e3f8b"
+  integrity sha512-cPQy1Ot7Urf4hQz+xnF1YKrqSyR0DRwozBmF+sGzceACWmueFl0CifYZC8RSmaiIyVh0RyWPxZ9F/eT67NX2lA==
   dependencies:
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/components" "7.0.12"
-    "@storybook/core-events" "7.0.12"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/components" "7.0.18"
+    "@storybook/core-events" "7.0.18"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
-    "@storybook/theming" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/manager-api" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
+    "@storybook/theming" "7.0.18"
+    "@storybook/types" "7.0.18"
     memoizerific "^1.11.3"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-controls@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-/+yBhswN1N7ttR1NGN94HE/25VELm4YuBtrkh+LJeKP/eQ5CZpLjexASN2GZcfmdnkwIYZAEH0X/AImLaCJAWA==
+"@storybook/addon-controls@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-7.0.18.tgz#e2875f7fed4befd542507e35f2534b7e9a64d7d1"
+  integrity sha512-mD6DE52CCMKugXk2Uab0QxwgfE76kFJroxASmnePnXUNWfP9EZJpJXYE3cyyBbmZuxa46VHDGGEGXQWRl4+Eog==
   dependencies:
-    "@storybook/blocks" "7.0.12"
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/components" "7.0.12"
-    "@storybook/core-common" "7.0.12"
-    "@storybook/manager-api" "7.0.12"
-    "@storybook/node-logger" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
-    "@storybook/theming" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/blocks" "7.0.18"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/components" "7.0.18"
+    "@storybook/core-common" "7.0.18"
+    "@storybook/manager-api" "7.0.18"
+    "@storybook/node-logger" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
+    "@storybook/theming" "7.0.18"
+    "@storybook/types" "7.0.18"
     lodash "^4.17.21"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-docs@7.0.12", "@storybook/addon-docs@^7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-zgg4sq34Zz8TN74+kSogxRHsIZ5gsIazJpa0osZp91nJQvsKUEfldjBtQWbBWzjVCrWmzOhW5/RLCnmCNm9y/w==
+"@storybook/addon-docs@7.0.18", "@storybook/addon-docs@^7.0.12":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-7.0.18.tgz#a39b0a1443158e0046a1b0746bab20344400f1da"
+  integrity sha512-oq+ZN5809gIRdTZQIpeK1F8BJtL1/VWo9rWvl6ymVOL/Xzdgd7AOfKf9Y99X35RcxAGysRIHLGJjF4bgLoY1Aw==
   dependencies:
     "@babel/core" "^7.20.2"
     "@babel/plugin-transform-react-jsx" "^7.19.0"
     "@jest/transform" "^29.3.1"
     "@mdx-js/react" "^2.1.5"
-    "@storybook/blocks" "7.0.12"
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/components" "7.0.12"
-    "@storybook/csf-plugin" "7.0.12"
-    "@storybook/csf-tools" "7.0.12"
+    "@storybook/blocks" "7.0.18"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/components" "7.0.18"
+    "@storybook/csf-plugin" "7.0.18"
+    "@storybook/csf-tools" "7.0.18"
     "@storybook/global" "^5.0.0"
     "@storybook/mdx2-csf" "^1.0.0"
-    "@storybook/node-logger" "7.0.12"
-    "@storybook/postinstall" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
-    "@storybook/react-dom-shim" "7.0.12"
-    "@storybook/theming" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/node-logger" "7.0.18"
+    "@storybook/postinstall" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
+    "@storybook/react-dom-shim" "7.0.18"
+    "@storybook/theming" "7.0.18"
+    "@storybook/types" "7.0.18"
     fs-extra "^11.1.0"
     remark-external-links "^8.0.0"
     remark-slug "^6.0.0"
     ts-dedent "^2.0.0"
 
 "@storybook/addon-essentials@^7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-Js2cxvauAf8fkA5D0QrqPPe/FvpY1DbJp61VNGh82Xu0zZrczCGYP3jkWG79vl0zllJNs7hnkV8W6xY1JWgLoA==
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-7.0.18.tgz#20c9a4b43e3e173dbfc0d742eb3e6bc7ba42b4c9"
+  integrity sha512-0XXu7xhtRefA1WxxorKk6BWeeB+7gQ+r2+bG1zQEfBgDYPR06YbPw4H79IZ8JiR97aJRsZBK5UUhOZMDrc5zcQ==
   dependencies:
-    "@storybook/addon-actions" "7.0.12"
-    "@storybook/addon-backgrounds" "7.0.12"
-    "@storybook/addon-controls" "7.0.12"
-    "@storybook/addon-docs" "7.0.12"
-    "@storybook/addon-highlight" "7.0.12"
-    "@storybook/addon-measure" "7.0.12"
-    "@storybook/addon-outline" "7.0.12"
-    "@storybook/addon-toolbars" "7.0.12"
-    "@storybook/addon-viewport" "7.0.12"
-    "@storybook/core-common" "7.0.12"
-    "@storybook/manager-api" "7.0.12"
-    "@storybook/node-logger" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
+    "@storybook/addon-actions" "7.0.18"
+    "@storybook/addon-backgrounds" "7.0.18"
+    "@storybook/addon-controls" "7.0.18"
+    "@storybook/addon-docs" "7.0.18"
+    "@storybook/addon-highlight" "7.0.18"
+    "@storybook/addon-measure" "7.0.18"
+    "@storybook/addon-outline" "7.0.18"
+    "@storybook/addon-toolbars" "7.0.18"
+    "@storybook/addon-viewport" "7.0.18"
+    "@storybook/core-common" "7.0.18"
+    "@storybook/manager-api" "7.0.18"
+    "@storybook/node-logger" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-highlight@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-ccIsBVjUlZ7cM1adSSFTqqWXiELPdDqfZLz4dWfDbiLyG3InC953ugtvoUWCIZpC2OOnjVLpF7Rbshq2O/QoMw==
+"@storybook/addon-highlight@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-highlight/-/addon-highlight-7.0.18.tgz#801d1242462b275aa4ba668ddcbf1474cd9f59ae"
+  integrity sha512-a3nfUhbu6whoDclIZSV/fzLj132tNNjV05ENTpuN3JpLoMd3+obDUWzeQUs9TetK4RBRN3ewM7sIMEI4oBpgmg==
   dependencies:
-    "@storybook/core-events" "7.0.12"
+    "@storybook/core-events" "7.0.18"
     "@storybook/global" "^5.0.0"
-    "@storybook/preview-api" "7.0.12"
+    "@storybook/preview-api" "7.0.18"
 
 "@storybook/addon-interactions@^7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-Rb1mv1RQrTd3sA/WwNTdv00rW+7APfvZEeZks6+8+kS1C4EFMDmLnVBZlPllFdo1BOnTCyer4GZZ5ncVkWNLyQ==
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-interactions/-/addon-interactions-7.0.18.tgz#c363517f10dd5a2e6c78c6a0ac690799158ab9ec"
+  integrity sha512-V3OD5lSj6Te6Kzc//2k2S79dLPk6Zu1pAbqWAN4RrdXyKj6YCiZ666GmVdiaG+24Qp5UuMeAkd1D05osJlOteA==
   dependencies:
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/components" "7.0.12"
-    "@storybook/core-common" "7.0.12"
-    "@storybook/core-events" "7.0.12"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/components" "7.0.18"
+    "@storybook/core-common" "7.0.18"
+    "@storybook/core-events" "7.0.18"
     "@storybook/global" "^5.0.0"
-    "@storybook/instrumenter" "7.0.12"
-    "@storybook/manager-api" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
-    "@storybook/theming" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/instrumenter" "7.0.18"
+    "@storybook/manager-api" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
+    "@storybook/theming" "7.0.18"
+    "@storybook/types" "7.0.18"
     jest-mock "^27.0.6"
     polished "^4.2.2"
     ts-dedent "^2.2.0"
 
 "@storybook/addon-links@^7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-6kGClsIpX9dRKc5bUAPNcp/4wlgPIxMrieUV+6k1dTsRQqbaEfxih/Fq259D5+yVBDNi3YAnvRjMiIibl8fa5A==
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-7.0.18.tgz#3c7f72f1a5b241718a57132991272e0bcc2ba7f4"
+  integrity sha512-xEwflt7bp9FRoZVeqPGb6d3s2Gh+/jaSmnyIxMxrBy2oovKIqu9ptolqz1AhjFOXfaLs9c2RAmJUuFZJtETLxA==
   dependencies:
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/core-events" "7.0.12"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/core-events" "7.0.18"
     "@storybook/csf" "^0.1.0"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
-    "@storybook/router" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/manager-api" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
+    "@storybook/router" "7.0.18"
+    "@storybook/types" "7.0.18"
     prop-types "^15.7.2"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-mdx-gfm@^7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-shl4LVrwwjw9H0IB9VzrOjtuvA28SrOKMsvwj06skQgH9aHJMA2SmgPnQIBoQmgUM+x+6g2vaSz9Z82iAo8ESw==
+"@storybook/addon-measure@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-measure/-/addon-measure-7.0.18.tgz#ee670ccb9cbaed6805343111d3b10839dc5e3ff1"
+  integrity sha512-iu8vQpGOA+CFYbWR6QNshj20o33OQ/xcTbp5P4U6xGYDUliUBbwJ2KLxcKlmIeBanBrBdz0jPFtHwY4dM1ZdKw==
   dependencies:
-    "@storybook/node-logger" "7.0.12"
-    remark-gfm "^3.0.1"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/components" "7.0.18"
+    "@storybook/core-events" "7.0.18"
+    "@storybook/global" "^5.0.0"
+    "@storybook/manager-api" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
+    "@storybook/types" "7.0.18"
+
+"@storybook/addon-outline@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-outline/-/addon-outline-7.0.18.tgz#69c5705135b199a814c82a3297c7870a3b56fe59"
+  integrity sha512-3vNWO7ezo6GIvidbz8JxFrKtfVEoTQN7tnZx+wpqmCF8ihBORewkpeMUnvgb9ZKjD0X7gE8eQvvG8KKWcyHDBQ==
+  dependencies:
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/components" "7.0.18"
+    "@storybook/core-events" "7.0.18"
+    "@storybook/global" "^5.0.0"
+    "@storybook/manager-api" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
+    "@storybook/types" "7.0.18"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-measure@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-Uq9cj9QmN7WKBQ6wqeneFmTqo1UQKXIc4CpGBEtJtfsYNLsERrVzOs/tRUf66Zl3lWgfFZxs1B5Ij6RDsYEjRw==
+"@storybook/addon-toolbars@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-7.0.18.tgz#619293c15c97a971f1e77b8b9a0c4173e08865cc"
+  integrity sha512-mwhq962o0WloHAeFjJ6BXO2nzdTo5KE2fqawPpqcB2lwXP6tvaA2tDWwgntjPCHejqWTS+ZTdO4/1xrMhWYt/g==
   dependencies:
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/components" "7.0.12"
-    "@storybook/core-events" "7.0.12"
-    "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/components" "7.0.18"
+    "@storybook/manager-api" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
+    "@storybook/theming" "7.0.18"
 
-"@storybook/addon-outline@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-eZPkm3mECdqx1EDJ0S6DAzZ9WZLPIsZH7fRy6vdJJuAgvnOSzkt7AEpA0hlgiNyXcFpE1Cav6/g12FUf4Zo82g==
+"@storybook/addon-viewport@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-7.0.18.tgz#976ab4ef2daa69718e6a98560414d3ee43f56b14"
+  integrity sha512-aVVLBsWXfGDX3z1pc93LWWdG5RUoJbGL/JJPMZGwXdwWpP8V3OBl8D8bgPymyg+MgwhSRZZDDGgnJaVGGwZ6bQ==
   dependencies:
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/components" "7.0.12"
-    "@storybook/core-events" "7.0.12"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/components" "7.0.18"
+    "@storybook/core-events" "7.0.18"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
-    "@storybook/types" "7.0.12"
-    ts-dedent "^2.0.0"
-
-"@storybook/addon-toolbars@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-7xRxk+999NVdEwzn2z1O9Tg5iuUSEXQ5jo+hiyK934VvuyqUsZnflKbSvwVEHb2W+DroaaXu8bdHWxGSH+6moQ==
-  dependencies:
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/components" "7.0.12"
-    "@storybook/manager-api" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
-    "@storybook/theming" "7.0.12"
-
-"@storybook/addon-viewport@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-pMgqtDQF8e9AErnRKbbSK9m1lcKn1dFSOkk0PgSBwIIjmha6q+GeT45EHQrQGtkLdtWT0iTktC8ivzIiGKmHkg==
-  dependencies:
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/components" "7.0.12"
-    "@storybook/core-events" "7.0.12"
-    "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
-    "@storybook/theming" "7.0.12"
+    "@storybook/manager-api" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
+    "@storybook/theming" "7.0.18"
     memoizerific "^1.11.3"
     prop-types "^15.7.2"
 
@@ -6885,14 +6881,14 @@
     global "^4.4.0"
     regenerator-runtime "^0.13.7"
 
-"@storybook/addons@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-yVADbWCFdb12cSpspeb+/6lfTNarPtZZLql49Bhu6E7PxECw/Q3kfHu0LXBLcSnU7f4QqQvQjp88ultt01ABBQ==
+"@storybook/addons@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-7.0.18.tgz#38dbbdb5281ce16ad0996bfc8a9e0bc5e7514460"
+  integrity sha512-+j9ItxWoVzarbllaV4WRaJpDM3P2aC5O6F3cPn4YkG/unb6HOs11WLAqFbzZnLYZNAFvWS8PYEAtqs1BxG66YQ==
   dependencies:
-    "@storybook/manager-api" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/manager-api" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
+    "@storybook/types" "7.0.18"
 
 "@storybook/api@6.5.16":
   version "6.5.16"
@@ -6917,30 +6913,30 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/api@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-wki9B7ZXOGwUq/FowDgEnkkX92oNpSg/6ES5Rh19NF3wV0ObLlgXMZ8cZKOLM6G0m/8lkKHGeNBunaLUnX7Yhw==
+"@storybook/api@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-7.0.18.tgz#6304f7f5160b404b61e4080da0a952074258cf1f"
+  integrity sha512-gikVJBR2z7LdepljmbvbsrYgywQm3jNEEEmjG0OwYDeYNjWPuoQSffT+LoyouaaCK90d1osJLl3062OkwlIG8g==
   dependencies:
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/manager-api" "7.0.12"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/manager-api" "7.0.18"
 
-"@storybook/blocks@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-MbJKjuTJ7xVbkUVwkEwb6vTYGrkRk4+Xtx1UGo+512o91ubqFs8hXwCHP+x/49RCIIQs5zl93Ig8fTtm+MejWw==
+"@storybook/blocks@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/blocks/-/blocks-7.0.18.tgz#996651ac813de2a810ba442ab77266961721d324"
+  integrity sha512-HLsuzmUdVIeFXEP5v5vyjnEePRNYjzltwTjCKQhHAlt8/aQZmREiIMOfoMoAa1Rd+On8Ib2DUd2cN10VS18H8A==
   dependencies:
-    "@storybook/channels" "7.0.12"
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/components" "7.0.12"
-    "@storybook/core-events" "7.0.12"
+    "@storybook/channels" "7.0.18"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/components" "7.0.18"
+    "@storybook/core-events" "7.0.18"
     "@storybook/csf" "^0.1.0"
-    "@storybook/docs-tools" "7.0.12"
+    "@storybook/docs-tools" "7.0.18"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
-    "@storybook/theming" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/manager-api" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
+    "@storybook/theming" "7.0.18"
+    "@storybook/types" "7.0.18"
     "@types/lodash" "^4.14.167"
     color-convert "^2.0.1"
     dequal "^2.0.2"
@@ -6953,15 +6949,15 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/builder-manager@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-bkZPSDH38/dUSsO087oQ8+goyaEDP/xD0/O61QcQ8EbaVeT6s6Qt7mMhqsLrtmEZHvPMQwKeIXhOJlRNNXB+SA==
+"@storybook/builder-manager@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/builder-manager/-/builder-manager-7.0.18.tgz#f964b8ef174441f9f35702c88bf8c47b819d7baf"
+  integrity sha512-yFMm3xuYkyg2hS1uz3CkvyvLzK7qJsDPVEh7lew8GiJK1Xx8cc+FnAOlRTjWNxvhfiT296wAMCTPWv7LeoSgqQ==
   dependencies:
     "@fal-works/esbuild-plugin-global-externals" "^2.1.2"
-    "@storybook/core-common" "7.0.12"
-    "@storybook/manager" "7.0.12"
-    "@storybook/node-logger" "7.0.12"
+    "@storybook/core-common" "7.0.18"
+    "@storybook/manager" "7.0.18"
+    "@storybook/node-logger" "7.0.18"
     "@types/ejs" "^3.1.1"
     "@types/find-cache-dir" "^3.2.1"
     "@yarnpkg/esbuild-plugin-pnp" "^3.0.0-rc.10"
@@ -7028,31 +7024,31 @@
     webpack-hot-middleware "^2.25.1"
     webpack-virtual-modules "^0.2.2"
 
-"@storybook/builder-webpack5@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-msrDWgNFu0kkQ8AOuOCqO+Z+b6iB2kNMhpTyreFbZfUwnEv35aXdULeSa/2mCD0/PFUUFZu+cVYflMyENZxe5w==
+"@storybook/builder-webpack5@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/builder-webpack5/-/builder-webpack5-7.0.18.tgz#587ef5088d5d37953c077b0f0163a83e1f31f238"
+  integrity sha512-ciDOHrnChHWjikQwsM+xGz70PGfWurcezCyRPPRY0zimyHWtlug6V1Q9dJAdEAFsxqFSZA/qg7gEcZyqdlTMaA==
   dependencies:
     "@babel/core" "^7.12.10"
-    "@storybook/addons" "7.0.12"
-    "@storybook/api" "7.0.12"
-    "@storybook/channel-postmessage" "7.0.12"
-    "@storybook/channel-websocket" "7.0.12"
-    "@storybook/channels" "7.0.12"
-    "@storybook/client-api" "7.0.12"
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/components" "7.0.12"
-    "@storybook/core-common" "7.0.12"
-    "@storybook/core-events" "7.0.12"
-    "@storybook/core-webpack" "7.0.12"
+    "@storybook/addons" "7.0.18"
+    "@storybook/api" "7.0.18"
+    "@storybook/channel-postmessage" "7.0.18"
+    "@storybook/channel-websocket" "7.0.18"
+    "@storybook/channels" "7.0.18"
+    "@storybook/client-api" "7.0.18"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/components" "7.0.18"
+    "@storybook/core-common" "7.0.18"
+    "@storybook/core-events" "7.0.18"
+    "@storybook/core-webpack" "7.0.18"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager-api" "7.0.12"
-    "@storybook/node-logger" "7.0.12"
-    "@storybook/preview" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
-    "@storybook/router" "7.0.12"
-    "@storybook/store" "7.0.12"
-    "@storybook/theming" "7.0.12"
+    "@storybook/manager-api" "7.0.18"
+    "@storybook/node-logger" "7.0.18"
+    "@storybook/preview" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
+    "@storybook/router" "7.0.18"
+    "@storybook/store" "7.0.18"
+    "@storybook/theming" "7.0.18"
     "@types/node" "^16.0.0"
     "@types/semver" "^7.3.4"
     babel-loader "^9.0.0"
@@ -7090,14 +7086,14 @@
     qs "^6.10.0"
     telejson "^6.0.8"
 
-"@storybook/channel-postmessage@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-Tc7kQZ5yxlZ44Nmmzec92JaDJ6UZ3Ze4cBfiHik4XcnM1PtN8hr8VFoC6a2AIm1ybfIRenfT5w9TH5yriiPIhw==
+"@storybook/channel-postmessage@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-7.0.18.tgz#deb843705aec24bd23e717a14678fdb1f7cce8ae"
+  integrity sha512-rpwBH5ANdPnugS6+7xG9qHSoS+aPSEnBxDKsONWFubfMTTXQuFkf/793rBbxGkoINdqh8kSdKOM2rIty6e9cmQ==
   dependencies:
-    "@storybook/channels" "7.0.12"
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/core-events" "7.0.12"
+    "@storybook/channels" "7.0.18"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/core-events" "7.0.18"
     "@storybook/global" "^5.0.0"
     qs "^6.10.0"
     telejson "^7.0.3"
@@ -7113,13 +7109,13 @@
     global "^4.4.0"
     telejson "^6.0.8"
 
-"@storybook/channel-websocket@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-UV6b9gX2mQLtXlKaFKCHcy+6MaK2od6BYqSJfainnBjDsMIXyhcf7fJaj0XQkJrbNnRBwGhw+6s8JxL98xp7Ew==
+"@storybook/channel-websocket@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-websocket/-/channel-websocket-7.0.18.tgz#d603b14b811e2c7a904cb7cc2f16a167e1124632"
+  integrity sha512-QYsZIfe23NN4i+oIdPKHaYBehk3a/HYk57a+M2oR3Frmv8IOqc/e31uH+xx5NxnjHrTJj7Y80ZJw6EKB682S6w==
   dependencies:
-    "@storybook/channels" "7.0.12"
-    "@storybook/client-logger" "7.0.12"
+    "@storybook/channels" "7.0.18"
+    "@storybook/client-logger" "7.0.18"
     "@storybook/global" "^5.0.0"
     telejson "^7.0.3"
 
@@ -7132,26 +7128,26 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/channels@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-KDdDmDs8kxAJU+vndTqTNazjLO+XoIPiTRlfP7mk7cgHiQXSjMYy3JSCQ7W0of0Q+9VSl/ve9CNbnGbcQF7rNQ==
+"@storybook/channels@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-7.0.18.tgz#0b5053ad6237ad7f619f1e17448d588de90ac235"
+  integrity sha512-rkA7ea0M3+dWS+71iHJdiZ5R2QuIdiVg0CgyLJHDagc1qej7pEVNhMWtppeq+X5Pwp9nkz8ZTQ7aCjTf6th0/A==
 
 "@storybook/cli@^7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-OABCRIujxsszIJ0CCpKg8Uj4C1UlAwBpBQhv2aMX3lA/pur6Od524syv2ypWu6J2FyvK/ooeyMbjoP7330cIuA==
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/cli/-/cli-7.0.18.tgz#5b00f26a6a5c1a3c76c986126f37e951ab25e4f0"
+  integrity sha512-9n4J4thiCUsGSXiRc6ZysqYUaCMCrpu0/qgC+5ngfFRuMmZgUV0y5+0fmaOhT2XjsonTTgucizO82i7+ottCVg==
   dependencies:
     "@babel/core" "^7.20.2"
     "@babel/preset-env" "^7.20.2"
     "@ndelangen/get-tarball" "^3.0.7"
-    "@storybook/codemod" "7.0.12"
-    "@storybook/core-common" "7.0.12"
-    "@storybook/core-server" "7.0.12"
-    "@storybook/csf-tools" "7.0.12"
-    "@storybook/node-logger" "7.0.12"
-    "@storybook/telemetry" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/codemod" "7.0.18"
+    "@storybook/core-common" "7.0.18"
+    "@storybook/core-server" "7.0.18"
+    "@storybook/csf-tools" "7.0.18"
+    "@storybook/node-logger" "7.0.18"
+    "@storybook/telemetry" "7.0.18"
+    "@storybook/types" "7.0.18"
     "@types/semver" "^7.3.4"
     boxen "^5.1.2"
     chalk "^4.1.0"
@@ -7169,6 +7165,7 @@
     globby "^11.0.2"
     jscodeshift "^0.14.0"
     leven "^3.1.0"
+    ora "^5.4.1"
     prettier "^2.8.0"
     prompts "^2.4.0"
     puppeteer-core "^2.1.1"
@@ -7207,13 +7204,13 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/client-api@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-kcB0wX9+pL9NW8+xFVABFZJeChsql9i2A69yUQQ8OCaJhB7LS3gl1Ri4zJhVHSuTTWBlbNUSPbu1yEkFiAWt/g==
+"@storybook/client-api@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-7.0.18.tgz#28a4e935949c83ece94a20cee2146b11b33c05d9"
+  integrity sha512-EdgE4om6nXZf/sDZcVMGMeKv4BPX+P3EKUfMHCHjlrbbeL0eeY8Ynf+u/wYrIYZPUodS8TEV5XchHVB8F7rLBQ==
   dependencies:
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
 
 "@storybook/client-logger@6.5.16":
   version "6.5.16"
@@ -7223,25 +7220,25 @@
     core-js "^3.8.2"
     global "^4.4.0"
 
-"@storybook/client-logger@7.0.12", "@storybook/client-logger@^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0":
-  version "7.0.12"
-  
-  integrity sha512-MQMtIgGEgdixvxnBvZ2m8hhc0DGJWeCpHtxg7oqBLBEBmCYFueTqDZHl4Z6SoCrK0a2YS5X/BIXOcEtP1ulMKw==
+"@storybook/client-logger@7.0.18", "@storybook/client-logger@^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-7.0.18.tgz#396858b53d0aa9485f173083ea27b7c1c48fa2dd"
+  integrity sha512-uKgFdVedYoRDZBVrE1IBdWNHDFln1IxWEeI+7ZiNSQwREG9swHpU5Fa8DceclM/oLjJRuzG1jFzv+XZY8894+Q==
   dependencies:
     "@storybook/global" "^5.0.0"
 
-"@storybook/codemod@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-eGbGZSglvbnY1omzRyEC4XP0FbpuCFKgjXmdHn9faGQUU5EJHwcGYYrRW8JZL3nEVIvNDuRAKzM3p0BVo1xeSQ==
+"@storybook/codemod@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/codemod/-/codemod-7.0.18.tgz#b5dbdcd0928ec60e09db58b48269506c056c3760"
+  integrity sha512-+9XFns29e8FpPLsqA8ZCQ3mNnIIKD3QnqGYkbkCVKi/G1fomvVQsIfsnkrYv5SobTbz29B4aNWxAaeSnO7/OGg==
   dependencies:
     "@babel/core" "~7.21.0"
     "@babel/preset-env" "~7.21.0"
     "@babel/types" "~7.21.2"
     "@storybook/csf" "^0.1.0"
-    "@storybook/csf-tools" "7.0.12"
-    "@storybook/node-logger" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/csf-tools" "7.0.18"
+    "@storybook/node-logger" "7.0.18"
+    "@storybook/types" "7.0.18"
     cross-spawn "^7.0.3"
     globby "^11.0.2"
     jscodeshift "^0.14.0"
@@ -7263,16 +7260,16 @@
     regenerator-runtime "^0.13.7"
     util-deprecate "^1.0.2"
 
-"@storybook/components@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-6TxByzYS4+LxwZRioGpP6Zh9If5ctjQs5OnR2UmQvP6HDjmMWYTntoHKIbDwAL9C6MrnQYpPOGCPkqrtODQ4/w==
+"@storybook/components@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-7.0.18.tgz#74ab115342e576b7644c83667a9daef5758fc3c8"
+  integrity sha512-Jn1CbF9UAKt8BVaZtuhmthpcZ02VMaCFXR0ISfDXCpiMKnylmpP0+WfXcoKLzz6yS+EW8EW5S9+Qq8xgQY8H7A==
   dependencies:
-    "@storybook/client-logger" "7.0.12"
+    "@storybook/client-logger" "7.0.18"
     "@storybook/csf" "^0.1.0"
     "@storybook/global" "^5.0.0"
-    "@storybook/theming" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/theming" "7.0.18"
+    "@storybook/types" "7.0.18"
     memoizerific "^1.11.3"
     use-resize-observer "^9.1.0"
     util-deprecate "^1.0.2"
@@ -7303,13 +7300,13 @@
     unfetch "^4.2.0"
     util-deprecate "^1.0.2"
 
-"@storybook/core-client@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-m0r+Vl3LfU8cJl8UqIwzh0sEN9I//nMaT8UIIm481AINhQTNihQcnYi9jRw7USjfz2fv5CYkg8cEr4KhI8QlRA==
+"@storybook/core-client@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/core-client/-/core-client-7.0.18.tgz#b70b9e8f0efd2dc1eb7fd925a8615b6ef32f07aa"
+  integrity sha512-ueExRZx6fd9LRssgdhDJ0bL4Ir2RrbXzJz/kjIT2KgYY3l7jkhe0dpT3bOgGKjQt0f7XMFU24t/r7aDLGMB+2Q==
   dependencies:
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
 
 "@storybook/core-common@6.5.16":
   version "6.5.16"
@@ -7367,13 +7364,13 @@
     util-deprecate "^1.0.2"
     webpack "4"
 
-"@storybook/core-common@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-PFVjYXHUxDQO1oqfqwQe7S3XoLNO0aZYEr9Zl0LiexlxxnU1v+TQjEfNd/H3T0xxpXlsgzhtEcagdzJeAKyh2g==
+"@storybook/core-common@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/core-common/-/core-common-7.0.18.tgz#7f897d666654cb034d5bc1a29b326a3566e634ba"
+  integrity sha512-HZAB1NIK/Yv0x9poyzqYcue2tx39+MAF1mbHgGy+JJZRerO2fRShgo8f8VPH9ChbFCoJ7isL5wNhgGdg9kp2kA==
   dependencies:
-    "@storybook/node-logger" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/node-logger" "7.0.18"
+    "@storybook/types" "7.0.18"
     "@types/node" "^16.0.0"
     "@types/pretty-hrtime" "^1.0.0"
     chalk "^4.1.0"
@@ -7399,10 +7396,10 @@
   dependencies:
     core-js "^3.8.2"
 
-"@storybook/core-events@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-VTmb/zjbz3o1bg+bATzLigVXMVDC/S1FP8CqIrz4mkiys52139FGzMandL2Y2AecPZPGss7ZRdfma28HKVYTRg==
+"@storybook/core-events@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-7.0.18.tgz#429e0b092c645bd283adb4836ac0a945e813f085"
+  integrity sha512-7gxHBQDezdKOeq/u1LL80Bwjfcwsv7XOS3yWQElcgqp+gLaYB6OwwgtkCB2yV6a6l4nep9IdPWE8G3TxIzn9xw==
 
 "@storybook/core-server@6.5.16":
   version "6.5.16"
@@ -7455,25 +7452,25 @@
     ws "^8.2.3"
     x-default-browser "^0.4.0"
 
-"@storybook/core-server@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-X35Kmg7y35Ph4J+gCDJrnVgBwlz4/DzOQofUS6rAbi4KvrPWDJXeM2OzOgx6B0abKl4CeMmjuc0tjbg4vbUFuA==
+"@storybook/core-server@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/core-server/-/core-server-7.0.18.tgz#9a4900afd956e27886238fbd4ee871c9e0dca29f"
+  integrity sha512-zGSGYSoCaSXM28OYKW7zsmpo8VU1icubXLRgdF21fbMhFN1WVS+bPA5+gSkAMf8acq5RNM8uSKskh7E2YDVEqA==
   dependencies:
     "@aw-web-design/x-default-browser" "1.4.88"
     "@discoveryjs/json-ext" "^0.5.3"
-    "@storybook/builder-manager" "7.0.12"
-    "@storybook/core-common" "7.0.12"
-    "@storybook/core-events" "7.0.12"
+    "@storybook/builder-manager" "7.0.18"
+    "@storybook/core-common" "7.0.18"
+    "@storybook/core-events" "7.0.18"
     "@storybook/csf" "^0.1.0"
-    "@storybook/csf-tools" "7.0.12"
+    "@storybook/csf-tools" "7.0.18"
     "@storybook/docs-mdx" "^0.1.0"
     "@storybook/global" "^5.0.0"
-    "@storybook/manager" "7.0.12"
-    "@storybook/node-logger" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
-    "@storybook/telemetry" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/manager" "7.0.18"
+    "@storybook/node-logger" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
+    "@storybook/telemetry" "7.0.18"
+    "@storybook/types" "7.0.18"
     "@types/detect-port" "^1.3.0"
     "@types/node" "^16.0.0"
     "@types/node-fetch" "^2.5.7"
@@ -7503,14 +7500,14 @@
     watchpack "^2.2.0"
     ws "^8.2.3"
 
-"@storybook/core-webpack@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-71tLTurZg5rYfjHuSUtnT8mcKc4CugvXh6DrJSf/1lTFarWvOZkYha9oh4gVokFWpAiK3GM9LE2DlCAozc9Xnw==
+"@storybook/core-webpack@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/core-webpack/-/core-webpack-7.0.18.tgz#b5134509ed6f33fe4815df561ff8c0f4b60c9ef3"
+  integrity sha512-U5e1r8cgZZzd/Lw9StIrACMVINCvucKm8ZfcFpPh0bjEv4+2qjo9tL3dLNh4OwKznvbzSE6pEO6cBjaphjTe1A==
   dependencies:
-    "@storybook/core-common" "7.0.12"
-    "@storybook/node-logger" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/core-common" "7.0.18"
+    "@storybook/node-logger" "7.0.18"
+    "@storybook/types" "7.0.18"
     "@types/node" "^16.0.0"
     ts-dedent "^2.0.0"
 
@@ -7522,12 +7519,12 @@
     "@storybook/core-client" "6.5.16"
     "@storybook/core-server" "6.5.16"
 
-"@storybook/csf-plugin@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-iiH0ynLQV5BYFc0o7RlSJS2S3GT/ffyfbV4rnCnPKdqyo4REEVvmhOuLhwzurtsXsjh+xF6VUYUDN+8/5mbkYw==
+"@storybook/csf-plugin@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/csf-plugin/-/csf-plugin-7.0.18.tgz#d601817ee8ee7eaf011a7e4a5d821356f5d1907e"
+  integrity sha512-Cr/Qr4/H4JIYgbbmDjQIYuqjp6nOaZga73R3KZcuClk27B90sI2ADegMYvORgbFgSkwweNQjgak6hLoOyogAhw==
   dependencies:
-    "@storybook/csf-tools" "7.0.12"
+    "@storybook/csf-tools" "7.0.18"
     unplugin "^0.10.2"
 
 "@storybook/csf-tools@6.5.16":
@@ -7550,17 +7547,17 @@
     regenerator-runtime "^0.13.7"
     ts-dedent "^2.0.0"
 
-"@storybook/csf-tools@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-EcDzKeENzs4awyjx0VxlONDLibiEtIPDP1XdOCcZGtv3nXXBFtS2WDsYhJHkwyvE37jWTyw2e4xKQmBi0Hjvbw==
+"@storybook/csf-tools@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/csf-tools/-/csf-tools-7.0.18.tgz#f61810f683b4eaa855a4a1ff876628835e82e965"
+  integrity sha512-0IJ2qdrxleTl67FUzsEvGcy96CY0OKyERE33tAsLNbvWcabdJKpLHP+rJwbsCw4z6IlS+kkmEffeFf5qRPTwkQ==
   dependencies:
     "@babel/generator" "~7.21.1"
     "@babel/parser" "~7.21.2"
     "@babel/traverse" "~7.21.2"
     "@babel/types" "~7.21.2"
     "@storybook/csf" "^0.1.0"
-    "@storybook/types" "7.0.12"
+    "@storybook/types" "7.0.18"
     fs-extra "^11.1.0"
     recast "^0.23.1"
     ts-dedent "^2.0.0"
@@ -7597,15 +7594,15 @@
     lodash "^4.17.21"
     regenerator-runtime "^0.13.7"
 
-"@storybook/docs-tools@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-+HykeQLgjyDyF9G7HqY0FHXlX7X5YpQcmNjftJzBrc/GO1EeO0M78d54avcOPyyTfuWOh7oZtSJ0MzjA1qrqaQ==
+"@storybook/docs-tools@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/docs-tools/-/docs-tools-7.0.18.tgz#ff1ed8f9e354e310af6872cb742a9a3a5fcb80ca"
+  integrity sha512-H95dW2DquGQ75ZVrFjvznPdCxT0eW6esDnemzLJB61KitcYZrWRavfrZzFtUcpzIa84OgY5pllFYt636v11LHQ==
   dependencies:
     "@babel/core" "^7.12.10"
-    "@storybook/core-common" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/core-common" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
+    "@storybook/types" "7.0.18"
     "@types/doctrine" "^0.0.3"
     doctrine "^3.0.0"
     lodash "^4.17.21"
@@ -7615,30 +7612,30 @@
   resolved "https://registry.yarnpkg.com/@storybook/global/-/global-5.0.0.tgz#b793d34b94f572c1d7d9e0f44fac4e0dbc9572ed"
   integrity sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==
 
-"@storybook/instrumenter@7.0.12", "@storybook/instrumenter@^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0":
-  version "7.0.12"
-  
-  integrity sha512-jx4rb4AMT1YIOpE0HCdfyLvpYU+94wPkC9vt7sZGWAp7nnYG+KO/lx3XCJaR9qQPIxVYejJtWkeGn4RID79SoQ==
+"@storybook/instrumenter@7.0.18", "@storybook/instrumenter@^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/instrumenter/-/instrumenter-7.0.18.tgz#7ac595948b726e55ebdde4288c12b1bd1b4d3781"
+  integrity sha512-fyQxeuVC0H+w3oyTuByE95xnAQ+l/WhUBVkHV2X+PWjg9vg9Y9JmrbNWynlvz5HLFlsY3qAWJh+ciVRVSvY5Jw==
   dependencies:
-    "@storybook/channels" "7.0.12"
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/core-events" "7.0.12"
+    "@storybook/channels" "7.0.18"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/core-events" "7.0.18"
     "@storybook/global" "^5.0.0"
-    "@storybook/preview-api" "7.0.12"
+    "@storybook/preview-api" "7.0.18"
 
-"@storybook/manager-api@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-3QXARtxpc6Xxqf5pviUw2UuhK53+IsINSljeWhAqdQ1Gzbywl67TpibTd7xVN6NKxhUH5Bzo9bIZTAzMZGqaKw==
+"@storybook/manager-api@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/manager-api/-/manager-api-7.0.18.tgz#9e0e011df04271b0ed7216a22f9c965e3b7ac4b9"
+  integrity sha512-anQkm09twL96YkKGXHa+LI0+yMaY6Jxs1lRaetHdMlIqN4VHBHhizHaMgtGfH6xCTuO3WdrKTN7cZii5RH7PBQ==
   dependencies:
-    "@storybook/channels" "7.0.12"
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/core-events" "7.0.12"
+    "@storybook/channels" "7.0.18"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/core-events" "7.0.18"
     "@storybook/csf" "^0.1.0"
     "@storybook/global" "^5.0.0"
-    "@storybook/router" "7.0.12"
-    "@storybook/theming" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/router" "7.0.18"
+    "@storybook/theming" "7.0.18"
+    "@storybook/types" "7.0.18"
     dequal "^2.0.2"
     lodash "^4.17.21"
     memoizerific "^1.11.3"
@@ -7688,10 +7685,10 @@
     webpack-dev-middleware "^3.7.3"
     webpack-virtual-modules "^0.2.2"
 
-"@storybook/manager@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-19BsDcwJOYXn6zEarxvNGDdYLUqZyhX92x6GPHSC4cf8BoxHuhmtnz5vOTZHusCxkKIu/C9W0H6wH2Ma47kDCg==
+"@storybook/manager@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/manager/-/manager-7.0.18.tgz#1dc5d64ecc683f5e7041eb8350eccaae6958204b"
+  integrity sha512-hasb8XDmkT9lyX2cwb3Xg0ngcNQ1QCNHKurl2YJtXowb1CvawGKokhnVUTso15NCnurolDyw/Wqka1sagfm+Mg==
 
 "@storybook/mdx1-csf@^0.0.1":
   version "0.0.1"
@@ -7726,33 +7723,33 @@
     npmlog "^5.0.1"
     pretty-hrtime "^1.0.3"
 
-"@storybook/node-logger@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-VL+NXzc9NuOP6/9alg4Sofz9kh8tmlo3p+UtCIYCHH088yCsB3XsNhkG9lF1C5EZVWcuHxc2u6MMF3ezOjvKfQ==
+"@storybook/node-logger@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-7.0.18.tgz#efed2e8b79964e7d999b64b0e99fa79f9356904e"
+  integrity sha512-cIeKEBvELtoVP/5UeQ01GJWZ7wM69/9Q+R5uOtNQBlwWFcCD6AVFWMRqq7ObMvdJG/okhXSF+sDetb+BF3zvdw==
   dependencies:
     "@types/npmlog" "^4.1.2"
     chalk "^4.1.0"
     npmlog "^5.0.1"
     pretty-hrtime "^1.0.3"
 
-"@storybook/postinstall@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-RKNvBLgABBTQwvGyF2jX4vP7OMLB3KvEEOQDoeOKjqyWfekDn5smI+eT714mtmKIH0YMcwmvzLgEdZkjmM/XhA==
+"@storybook/postinstall@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/postinstall/-/postinstall-7.0.18.tgz#348711fea8ccf66255904811fa33316d0f54445e"
+  integrity sha512-ObIwAK2UiYhXN/7UifISQgBoH5jnyxh6T8kvCw83YhC78SDOPNgIGjToJECizJ7iubtqAWtCfCT5TrGEpyLGbg==
 
-"@storybook/preset-react-webpack@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-EBgP5p8uiwJXPpM5M6mC4SrKCKSeQEJI+oQ36olUIB7PUhysiVFhLB+rOIgkXc3nhX1uRTO/PYefd9PBMwE11A==
+"@storybook/preset-react-webpack@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/preset-react-webpack/-/preset-react-webpack-7.0.18.tgz#fbdd707af6b7c2b63b4db97946102f09c18f7aaa"
+  integrity sha512-ISqq+DWzxHrQUHt83+tq7TKQETQcwekUnNYKgFzN8dVgZWqRS+/PqX+7c07Qa3h/QIWgMjPA6SPN4Z12tV4qpA==
   dependencies:
     "@babel/preset-flow" "^7.18.6"
     "@babel/preset-react" "^7.18.6"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.5.5"
-    "@storybook/core-webpack" "7.0.12"
-    "@storybook/docs-tools" "7.0.12"
-    "@storybook/node-logger" "7.0.12"
-    "@storybook/react" "7.0.12"
+    "@storybook/core-webpack" "7.0.18"
+    "@storybook/docs-tools" "7.0.18"
+    "@storybook/node-logger" "7.0.18"
+    "@storybook/react" "7.0.18"
     "@storybook/react-docgen-typescript-plugin" "1.0.6--canary.9.0c3f3b7.0"
     "@types/node" "^16.0.0"
     "@types/semver" "^7.3.4"
@@ -7763,18 +7760,18 @@
     semver "^7.3.7"
     webpack "5"
 
-"@storybook/preview-api@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-YI/AfHszIOYt967fsRlc7j6I0zZB+RSsBwD/nMA8y9vszdpQ0MgRhxHgQxFf6cgqbuQcdCsnTIpT0iQ4GHjDXg==
+"@storybook/preview-api@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/preview-api/-/preview-api-7.0.18.tgz#ef012f984a2c0b9395b1b75b4f6e25643912c67d"
+  integrity sha512-xxtC0gPGMn/DbwvS4ZuJaBwfFNsjUCf0yLYHFrNe6fxncbvcLZ550RuyUwYuIRfsiKrlgfa3QmmCa4JM/JesHQ==
   dependencies:
-    "@storybook/channel-postmessage" "7.0.12"
-    "@storybook/channels" "7.0.12"
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/core-events" "7.0.12"
+    "@storybook/channel-postmessage" "7.0.18"
+    "@storybook/channels" "7.0.18"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/core-events" "7.0.18"
     "@storybook/csf" "^0.1.0"
     "@storybook/global" "^5.0.0"
-    "@storybook/types" "7.0.12"
+    "@storybook/types" "7.0.18"
     "@types/qs" "^6.9.5"
     dequal "^2.0.2"
     lodash "^4.17.21"
@@ -7806,10 +7803,10 @@
     unfetch "^4.2.0"
     util-deprecate "^1.0.2"
 
-"@storybook/preview@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-za8El/nnkyAo/uqyqAg7PMuP6DSdPoEnDRyIk4LzY7sAGly6i4Uge377cdo1nUBQLS5S4kKIc4xf8TUegb3G1Q==
+"@storybook/preview@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/preview/-/preview-7.0.18.tgz#8f8ac8b1bce674d52c1f9640073fb93b786e2f26"
+  integrity sha512-L53p2eo8G12U6tp7hD3mk5tdWFXLvdEyV9e7a1x9bw1LfH15K/bp8lO6U/W1kkpse7+rqWBqoTjJC1Ktm5Sxog==
 
 "@storybook/react-docgen-typescript-plugin@1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0":
   version "1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0"
@@ -7837,33 +7834,33 @@
     react-docgen-typescript "^2.2.2"
     tslib "^2.0.0"
 
-"@storybook/react-dom-shim@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-4z9J54TD7uphxPqSuLEzeKTV4oF8Fmv8qFfnT0XZJ2mpYTC2NTbkYoYZQ8N0eYzvNOk6xgfpDqBdmIANf4NaYw==
+"@storybook/react-dom-shim@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/react-dom-shim/-/react-dom-shim-7.0.18.tgz#d2ac94c50c48b92417338823c8a7eabace308771"
+  integrity sha512-O1FRypR8q1katjbznnxI+NtALd2gaWa7KnTwbIDf+ddZltXHMZ8xMiEGEtAMrfXlIuqIr9UvmLRfKZC/ysuA+g==
 
 "@storybook/react-webpack5@^7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-VHGByQ6SndT0pgf4lfDRkgJCwg6YVFBciZTKM8DB0AGz2OP+sQ2F4lBf+VItYLu1IS3zXMIpD79dmmpd988Cwg==
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/react-webpack5/-/react-webpack5-7.0.18.tgz#95c0b27fa1ad5a19ed4bdc884193b4f665948c8d"
+  integrity sha512-FS25UMhXhbJ203XxW6YOWZCeMLCKBLu+X3W2r9JgVXfFdBEVsx3Aldsy3yJRqi1MGIqC6hLy94v79lJldKs7Ig==
   dependencies:
-    "@storybook/builder-webpack5" "7.0.12"
-    "@storybook/preset-react-webpack" "7.0.12"
-    "@storybook/react" "7.0.12"
+    "@storybook/builder-webpack5" "7.0.18"
+    "@storybook/preset-react-webpack" "7.0.18"
+    "@storybook/react" "7.0.18"
     "@types/node" "^16.0.0"
 
-"@storybook/react@7.0.12", "@storybook/react@^7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-dKHKc02LSgn3St7U/xj/Rr2DFLbS4dWQka+pS/AOvPPvMAR2gGHVhkmoFuFMf176hUTuE5MCoWBoNJIRMz7ZiQ==
+"@storybook/react@7.0.18", "@storybook/react@^7.0.12":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-7.0.18.tgz#d6f4919e22e169062e794b8a742f1b1978abf0ab"
+  integrity sha512-lumUbHYeuL3qa4SZR9K2YC4UIt1hwW19GuI/6f2HEV5gR9QHHSJHg9HD9pjcxv4fQaiG81ACZ0Sg6lyUkcJvuQ==
   dependencies:
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/core-client" "7.0.12"
-    "@storybook/docs-tools" "7.0.12"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/core-client" "7.0.18"
+    "@storybook/docs-tools" "7.0.18"
     "@storybook/global" "^5.0.0"
-    "@storybook/preview-api" "7.0.12"
-    "@storybook/react-dom-shim" "7.0.12"
-    "@storybook/types" "7.0.12"
+    "@storybook/preview-api" "7.0.18"
+    "@storybook/react-dom-shim" "7.0.18"
+    "@storybook/types" "7.0.18"
     "@types/escodegen" "^0.0.6"
     "@types/estree" "^0.0.51"
     "@types/node" "^16.0.0"
@@ -7931,12 +7928,12 @@
     qs "^6.10.0"
     regenerator-runtime "^0.13.7"
 
-"@storybook/router@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-dOtBiCBGeDem86BCWR7AlTVQjoBk0yw/XZLXS9qcpUfpe+UDjd0Rh21ZdEEMHG1Wfu4d2AhhG5l/JSJ1IE83jQ==
+"@storybook/router@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-7.0.18.tgz#c82146a6d4894c6d3d55b80a447010bebf192804"
+  integrity sha512-Mue4s/BnKgdYcsiW9yuvW3qL9k3AgYn5HIhnkBExAteyiUGdAca4IJFhArmGgFktgeLc4ecBQ7sgaCljApnbgg==
   dependencies:
-    "@storybook/client-logger" "7.0.12"
+    "@storybook/client-logger" "7.0.18"
     memoizerific "^1.11.3"
     qs "^6.10.0"
 
@@ -7969,13 +7966,13 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/store@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-+gqs6y55fXp9vLrq9VyCGoAHbjfEBMZClkCNksPUBPoLRCY0knxGvhIOoDdcqHkHpm3AQGsfW/ESurbLj/Q76Q==
+"@storybook/store@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/store/-/store-7.0.18.tgz#3b9dce8a3fa6ceea5b650254ba284ef6c8bb4740"
+  integrity sha512-rvQOG7R1+r77Y9jwNqQB3EKW6D5kzIGoxqzFHd1oDqeY5+vqPXHC/J5iDrl8TZ4GES7ZMAHpkTySbY+rRQK7Ng==
   dependencies:
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/preview-api" "7.0.12"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/preview-api" "7.0.18"
 
 "@storybook/telemetry@6.5.16":
   version "6.5.16"
@@ -7995,13 +7992,13 @@
     read-pkg-up "^7.0.1"
     regenerator-runtime "^0.13.7"
 
-"@storybook/telemetry@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-oxqe15bn5W+1pLpLjXTfj3H+YPZq3jExjdJwTCUHtFrrsNs0k6dyqAUk8qTOUqOTclANHb6vlNBFJDvZ6qbfEQ==
+"@storybook/telemetry@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/telemetry/-/telemetry-7.0.18.tgz#ccf52de6c82a54953eb2a30270edc5d7caf12cd1"
+  integrity sha512-JP5Z7lGU+oKjNmz2cZW5J7EerwyWBBPOU+NvvooZsymIx02ZvJ4ClmFtolJnBM7m4KoAy50JxV5NQWi+q8PicQ==
   dependencies:
-    "@storybook/client-logger" "7.0.12"
-    "@storybook/core-common" "7.0.12"
+    "@storybook/client-logger" "7.0.18"
+    "@storybook/core-common" "7.0.18"
     chalk "^4.1.0"
     detect-package-manager "^2.0.1"
     fetch-retry "^5.0.2"
@@ -8012,7 +8009,7 @@
 
 "@storybook/testing-library@^0.1.0":
   version "0.1.0"
-  
+  resolved "https://registry.yarnpkg.com/@storybook/testing-library/-/testing-library-0.1.0.tgz#1839639765a2de113416d0fa16f9d108dfa6af63"
   integrity sha512-g947f4LJZw3IluBhysMKLJXByAFiSxnGuooENqU+ZPt/GTrz1I9GDBlhmoTJahuFkVbwHvziAl/8riY2Re921g==
   dependencies:
     "@storybook/client-logger" "^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0"
@@ -8031,22 +8028,22 @@
     memoizerific "^1.11.3"
     regenerator-runtime "^0.13.7"
 
-"@storybook/theming@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-frBkvH7LF8j23ODaywLK4m4LLscw49oKblkZ+30QZkBAzRf2o3a/QSZW2V1zfBo7ygcXiUJ5bIjh7Y17mMJqbQ==
+"@storybook/theming@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-7.0.18.tgz#566f5f42c9324b734f8aa9be4d16221278054734"
+  integrity sha512-P1gMKa/mKQHIMq0sxBIwTzAcF6v/6hrc62YmkuV62vXu+8zNV2YWbRwywqm3Q6faZEadmb/bL9+z8whaKhCL/g==
   dependencies:
     "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
-    "@storybook/client-logger" "7.0.12"
+    "@storybook/client-logger" "7.0.18"
     "@storybook/global" "^5.0.0"
     memoizerific "^1.11.3"
 
-"@storybook/types@7.0.12":
-  version "7.0.12"
-  
-  integrity sha512-nlvU4MyO2grwPCRQ8alA3AnY1bQxGJ6A4QgJu+1MhtjVenifFlxOQX4H1OiA+YXfjlV096oO5LrxvetJPFAKKQ==
+"@storybook/types@7.0.18":
+  version "7.0.18"
+  resolved "https://registry.yarnpkg.com/@storybook/types/-/types-7.0.18.tgz#9418da288db3a1258996aab17fd49ca4eb810b7a"
+  integrity sha512-qPop2CbvmX42/BX29YT9jIzW2TlMcMjAE+KCpcKLBiD1oT5DJ1fhMzpe6RW9HkMegkBxjWx54iamN4oHM/pwcQ==
   dependencies:
-    "@storybook/channels" "7.0.12"
+    "@storybook/channels" "7.0.18"
     "@types/babel__core" "^7.0.0"
     "@types/express" "^4.7.0"
     file-system-cache "^2.0.0"
@@ -11227,11 +11224,6 @@ ccount@^1.0.0:
   resolved "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
 
-ccount@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
-  integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
-
 cdk-assets@2.62.2:
   version "2.62.2"
   resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-2.62.2.tgz#90ce552661f3ac3959f45b555b4157d35bc994ff"
@@ -13349,11 +13341,6 @@ escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
-
-escape-string-regexp@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
-  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
 escodegen@^1.8.1:
   version "1.14.3"
@@ -18873,11 +18860,6 @@ markdown-extensions@^1.0.0:
   resolved "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-1.1.1.tgz#fea03b539faeaee9b4ef02a3769b455b189f7fc3"
   integrity sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==
 
-markdown-table@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-3.0.3.tgz#e6331d30e493127e031dd385488b5bd326e4a6bd"
-  integrity sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==
-
 markdown-to-jsx@^7.1.8:
   version "7.1.9"
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.9.tgz#1ffae0cda07c189163d273bd57a5b8f8f8745586"
@@ -18924,16 +18906,6 @@ mdast-util-definitions@^5.0.0:
     "@types/unist" "^2.0.0"
     unist-util-visit "^4.0.0"
 
-mdast-util-find-and-replace@^2.0.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz#cc2b774f7f3630da4bd592f61966fecade8b99b1"
-  integrity sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    escape-string-regexp "^5.0.0"
-    unist-util-is "^5.0.0"
-    unist-util-visit-parents "^5.0.0"
-
 mdast-util-from-markdown@^1.0.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.0.tgz#0214124154f26154a2b3f9d401155509be45e894"
@@ -18960,64 +18932,6 @@ mdast-util-frontmatter@^1.0.0:
     "@types/mdast" "^3.0.0"
     mdast-util-to-markdown "^1.3.0"
     micromark-extension-frontmatter "^1.0.0"
-
-mdast-util-gfm-autolink-literal@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.3.tgz#67a13abe813d7eba350453a5333ae1bc0ec05c06"
-  integrity sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    ccount "^2.0.0"
-    mdast-util-find-and-replace "^2.0.0"
-    micromark-util-character "^1.0.0"
-
-mdast-util-gfm-footnote@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-1.0.2.tgz#ce5e49b639c44de68d5bf5399877a14d5020424e"
-  integrity sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    mdast-util-to-markdown "^1.3.0"
-    micromark-util-normalize-identifier "^1.0.0"
-
-mdast-util-gfm-strikethrough@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz#5470eb105b483f7746b8805b9b989342085795b7"
-  integrity sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    mdast-util-to-markdown "^1.3.0"
-
-mdast-util-gfm-table@^1.0.0:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.7.tgz#3552153a146379f0f9c4c1101b071d70bbed1a46"
-  integrity sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    markdown-table "^3.0.0"
-    mdast-util-from-markdown "^1.0.0"
-    mdast-util-to-markdown "^1.3.0"
-
-mdast-util-gfm-task-list-item@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz#b280fcf3b7be6fd0cc012bbe67a59831eb34097b"
-  integrity sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    mdast-util-to-markdown "^1.3.0"
-
-mdast-util-gfm@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm/-/mdast-util-gfm-2.0.2.tgz#e92f4d8717d74bdba6de57ed21cc8b9552e2d0b6"
-  integrity sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==
-  dependencies:
-    mdast-util-from-markdown "^1.0.0"
-    mdast-util-gfm-autolink-literal "^1.0.0"
-    mdast-util-gfm-footnote "^1.0.0"
-    mdast-util-gfm-strikethrough "^1.0.0"
-    mdast-util-gfm-table "^1.0.0"
-    mdast-util-gfm-task-list-item "^1.0.0"
-    mdast-util-to-markdown "^1.0.0"
 
 mdast-util-mdx-expression@^1.0.0:
   version "1.3.2"
@@ -19274,86 +19188,6 @@ micromark-extension-frontmatter@^1.0.0:
     fault "^2.0.0"
     micromark-util-character "^1.0.0"
     micromark-util-symbol "^1.0.0"
-
-micromark-extension-gfm-autolink-literal@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-1.0.3.tgz#dc589f9c37eaff31a175bab49f12290edcf96058"
-  integrity sha512-i3dmvU0htawfWED8aHMMAzAVp/F0Z+0bPh3YrbTPPL1v4YAlCZpy5rBO5p0LPYiZo0zFVkoYh7vDU7yQSiCMjg==
-  dependencies:
-    micromark-util-character "^1.0.0"
-    micromark-util-sanitize-uri "^1.0.0"
-    micromark-util-symbol "^1.0.0"
-    micromark-util-types "^1.0.0"
-    uvu "^0.5.0"
-
-micromark-extension-gfm-footnote@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-1.0.4.tgz#cbfd8873b983e820c494498c6dac0105920818d5"
-  integrity sha512-E/fmPmDqLiMUP8mLJ8NbJWJ4bTw6tS+FEQS8CcuDtZpILuOb2kjLqPEeAePF1djXROHXChM/wPJw0iS4kHCcIg==
-  dependencies:
-    micromark-core-commonmark "^1.0.0"
-    micromark-factory-space "^1.0.0"
-    micromark-util-character "^1.0.0"
-    micromark-util-normalize-identifier "^1.0.0"
-    micromark-util-sanitize-uri "^1.0.0"
-    micromark-util-symbol "^1.0.0"
-    micromark-util-types "^1.0.0"
-    uvu "^0.5.0"
-
-micromark-extension-gfm-strikethrough@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-1.0.4.tgz#162232c284ffbedd8c74e59c1525bda217295e18"
-  integrity sha512-/vjHU/lalmjZCT5xt7CcHVJGq8sYRm80z24qAKXzaHzem/xsDYb2yLL+NNVbYvmpLx3O7SYPuGL5pzusL9CLIQ==
-  dependencies:
-    micromark-util-chunked "^1.0.0"
-    micromark-util-classify-character "^1.0.0"
-    micromark-util-resolve-all "^1.0.0"
-    micromark-util-symbol "^1.0.0"
-    micromark-util-types "^1.0.0"
-    uvu "^0.5.0"
-
-micromark-extension-gfm-table@^1.0.0:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-table/-/micromark-extension-gfm-table-1.0.5.tgz#7b708b728f8dc4d95d486b9e7a2262f9cddbcbb4"
-  integrity sha512-xAZ8J1X9W9K3JTJTUL7G6wSKhp2ZYHrFk5qJgY/4B33scJzE2kpfRL6oiw/veJTbt7jiM/1rngLlOKPWr1G+vg==
-  dependencies:
-    micromark-factory-space "^1.0.0"
-    micromark-util-character "^1.0.0"
-    micromark-util-symbol "^1.0.0"
-    micromark-util-types "^1.0.0"
-    uvu "^0.5.0"
-
-micromark-extension-gfm-tagfilter@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-1.0.1.tgz#fb2e303f7daf616db428bb6a26e18fda14a90a4d"
-  integrity sha512-Ty6psLAcAjboRa/UKUbbUcwjVAv5plxmpUTy2XC/3nJFL37eHej8jrHrRzkqcpipJliuBH30DTs7+3wqNcQUVA==
-  dependencies:
-    micromark-util-types "^1.0.0"
-
-micromark-extension-gfm-task-list-item@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-1.0.3.tgz#7683641df5d4a09795f353574d7f7f66e47b7fc4"
-  integrity sha512-PpysK2S1Q/5VXi72IIapbi/jliaiOFzv7THH4amwXeYXLq3l1uo8/2Be0Ac1rEwK20MQEsGH2ltAZLNY2KI/0Q==
-  dependencies:
-    micromark-factory-space "^1.0.0"
-    micromark-util-character "^1.0.0"
-    micromark-util-symbol "^1.0.0"
-    micromark-util-types "^1.0.0"
-    uvu "^0.5.0"
-
-micromark-extension-gfm@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm/-/micromark-extension-gfm-2.0.1.tgz#40f3209216127a96297c54c67f5edc7ef2d1a2a2"
-  integrity sha512-p2sGjajLa0iYiGQdT0oelahRYtMWvLjy8J9LOCxzIQsllMCGLbsLW+Nc+N4vi02jcRJvedVJ68cjelKIO6bpDA==
-  dependencies:
-    micromark-extension-gfm-autolink-literal "^1.0.0"
-    micromark-extension-gfm-footnote "^1.0.0"
-    micromark-extension-gfm-strikethrough "^1.0.0"
-    micromark-extension-gfm-table "^1.0.0"
-    micromark-extension-gfm-tagfilter "^1.0.0"
-    micromark-extension-gfm-task-list-item "^1.0.0"
-    micromark-util-combine-extensions "^1.0.0"
-    micromark-util-types "^1.0.0"
 
 micromark-extension-mdx-expression@^1.0.0:
   version "1.0.4"
@@ -20523,12 +20357,12 @@ nx@15.9.2, nx@^15.9.2:
     "@nrwl/nx-win32-arm64-msvc" "15.9.2"
     "@nrwl/nx-win32-x64-msvc" "15.9.2"
 
-nx@16.2.1:
-  version "16.2.1"
-  
-  integrity sha512-O+yGcYIQtYKYagbIuOQFk1P8ki5PHn0BZjdZpsa4K8UZ4pCaRWzlwWwwUL91FUJe6tdhic5710DwAAakbGKP7Q==
+nx@16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/nx/-/nx-16.3.2.tgz#92a2d7ef06d15b3b111b7cf9d35de08de0a22d90"
+  integrity sha512-fOzCVL7qoCJAcYTJwvJ9j+PSaL791ro4AICWuLxaphZsp2jcLoav4Ev7ONPks2Wlkt8FS9bee3nqQ3w1ya36Og==
   dependencies:
-    "@nrwl/tao" "16.2.1"
+    "@nrwl/tao" "16.3.2"
     "@parcel/watcher" "2.0.4"
     "@yarnpkg/lockfile" "^1.1.0"
     "@yarnpkg/parsers" "^3.0.0-rc.18"
@@ -20563,15 +20397,16 @@ nx@16.2.1:
     yargs "^17.6.2"
     yargs-parser "21.1.1"
   optionalDependencies:
-    "@nx/nx-darwin-arm64" "16.2.1"
-    "@nx/nx-darwin-x64" "16.2.1"
-    "@nx/nx-linux-arm-gnueabihf" "16.2.1"
-    "@nx/nx-linux-arm64-gnu" "16.2.1"
-    "@nx/nx-linux-arm64-musl" "16.2.1"
-    "@nx/nx-linux-x64-gnu" "16.2.1"
-    "@nx/nx-linux-x64-musl" "16.2.1"
-    "@nx/nx-win32-arm64-msvc" "16.2.1"
-    "@nx/nx-win32-x64-msvc" "16.2.1"
+    "@nx/nx-darwin-arm64" "16.3.2"
+    "@nx/nx-darwin-x64" "16.3.2"
+    "@nx/nx-freebsd-x64" "16.3.2"
+    "@nx/nx-linux-arm-gnueabihf" "16.3.2"
+    "@nx/nx-linux-arm64-gnu" "16.3.2"
+    "@nx/nx-linux-arm64-musl" "16.3.2"
+    "@nx/nx-linux-x64-gnu" "16.3.2"
+    "@nx/nx-linux-x64-musl" "16.3.2"
+    "@nx/nx-win32-arm64-msvc" "16.3.2"
+    "@nx/nx-win32-x64-msvc" "16.3.2"
 
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
@@ -22739,16 +22574,6 @@ remark-frontmatter@4.0.1:
     micromark-extension-frontmatter "^1.0.0"
     unified "^10.0.0"
 
-remark-gfm@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-3.0.1.tgz#0b180f095e3036545e9dddac0e8df3fa5cfee54f"
-  integrity sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    mdast-util-gfm "^2.0.0"
-    micromark-extension-gfm "^2.0.0"
-    unified "^10.0.0"
-
 remark-mdx-frontmatter@^1.0.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/remark-mdx-frontmatter/-/remark-mdx-frontmatter-1.1.1.tgz#54cfb3821fbb9cb6057673e0570ae2d645f6fe32"
@@ -23125,7 +22950,7 @@ rxjs@^7.5.5:
 
 rxjs@^7.8.0:
   version "7.8.1"
-  
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
   integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
   dependencies:
     tslib "^2.1.0"
@@ -23892,7 +23717,7 @@ store2@^2.12.0, store2@^2.14.2:
 
 storybook-addon-pseudo-states@^2.0.1:
   version "2.0.1"
-  
+  resolved "https://registry.yarnpkg.com/storybook-addon-pseudo-states/-/storybook-addon-pseudo-states-2.0.1.tgz#3c2f7219eb1c9aa125a33fe7d7570957dbc81578"
   integrity sha512-k7btLopDyoZELDSvVYMzNhEInf+IWns8NGJbvCPBrZxkukhnYmzQ9aLxjPDwjBTfLxSewu9Yfx2qKGzKDj+/ng==
 
 storybook-version@^0.1.1:
@@ -25144,7 +24969,7 @@ unist-util-visit-parents@^3.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
 
-unist-util-visit-parents@^5.0.0, unist-util-visit-parents@^5.1.1:
+unist-util-visit-parents@^5.1.1:
   version "5.1.3"
   resolved "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz#b4520811b0ca34285633785045df7a8d6776cfeb"
   integrity sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==


### PR DESCRIPTION
## Changes

- Updated all AutoLayout stories using new designs
  - Made each story interactive
  - Added descriptions to each property and linked to Figma documentation
- Added a few new stories
- Cleaned up configs
- removed `addon-mdx-gfm` as it was only installed as part of storybook 7 migration (was giving warnings on startup)

## TODO
- [ ] Alignment stories being handled separately in this PR: https://github.com/rangle/radius-monorepo-react/pull/95