### PR TITLE
fix: load fonts

### DIFF
--- a/apps/demo/app/root.tsx
+++ b/apps/demo/app/root.tsx
@@ -9,7 +9,8 @@ import {
   ScrollRestoration,
 } from '@remix-run/react';
 import styles from '@rangle/radius-foundations/styles.css';
-import fonts from '../../../radius/brands/radius/fonts/fonts.css';
+import fontsRadius from '@rangle/radius-foundations/generated/brands/radius/fonts/fonts.css';
+import fontsSaddles from '@rangle/radius-foundations/generated/brands/saddles/fonts/fonts.css';
 import { useMutationObserver } from './utils/demo.utils';
 import { css, Global } from '@emotion/react';
 
@@ -27,7 +28,11 @@ export function links() {
     },
     {
       rel: 'stylesheet',
-      href: fonts,
+      href: fontsRadius,
+    },
+    {
+      rel: 'stylesheet',
+      href: fontsSaddles,
     },
   ];
 }

--- a/apps/demo/app/root.tsx
+++ b/apps/demo/app/root.tsx
@@ -9,6 +9,7 @@ import {
   ScrollRestoration,
 } from '@remix-run/react';
 import styles from '@rangle/radius-foundations/styles.css';
+import fonts from '../../../radius/brands/radius/fonts/fonts.css';
 import { useMutationObserver } from './utils/demo.utils';
 import { css, Global } from '@emotion/react';
 
@@ -23,6 +24,10 @@ export function links() {
     {
       rel: 'stylesheet',
       href: styles,
+    },
+    {
+      rel: 'stylesheet',
+      href: fonts,
     },
   ];
 }


### PR DESCRIPTION
Load it from the brands folder for now - it currently goes to the brand directory which should be reconciled

![Screenshot 2023-06-07 at 10 44 57 AM](https://github.com/rangle/radius-monorepo-react/assets/1680390/648ab277-e7d6-40eb-a164-9c7dfd8c7c53)
