### PR TITLE
Add default padding to storybook

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,9 +1,3 @@
 <!-- Pull in static files served from your Static directory or the internet -->
 <link rel="stylesheet" media="all" href="./fonts.css" />
 <link rel="stylesheet" media="all" href="styles.css" />
-
-<style>
-  .sb-show-main.sb-main-padded {
-    padding: 0;
-  }
-</style>

--- a/library/core-components/components/footer/footer.stories.tsx
+++ b/library/core-components/components/footer/footer.stories.tsx
@@ -17,6 +17,7 @@ const meta: Meta<typeof RadiusFooter> = {
   title: 'Radius Examples / Footer',
   parameters: {
     badges: [BADGE.BETA],
+    layout: 'fullscreen',
   },
   argTypes: {
     as: {

--- a/library/core-components/components/hero/hero.stories.tsx
+++ b/library/core-components/components/hero/hero.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<RadiusHeroProps> = {
   title: 'Radius Examples / Hero',
   parameters: {
     badges: [BADGE.BETA],
+    layout: 'fullscreen',
   },
   argTypes: {
     className: { table: { disable: true } },

--- a/library/core-components/components/nav/nav.stories.tsx
+++ b/library/core-components/components/nav/nav.stories.tsx
@@ -22,6 +22,7 @@ const meta: Meta<typeof RadiusNav> = {
   title: 'Radius Examples / Nav',
   parameters: {
     badges: [BADGE.BETA],
+    layout: 'fullscreen',
   },
   argTypes: {
     as: {


### PR DESCRIPTION
## Changes
- fixed an issue where the default padding in storybook was removed
- added `layout: fullscreen` to Hero, Footer, and Nav stories to hide padding

Before | After
-- | --
<img width="830" alt="Screenshot 2023-06-07 at 11 53 30 AM" src="https://github.com/rangle/radius-monorepo-react/assets/23023263/b4035a36-39f3-42d0-8b4f-90c535550e97"> | <img width="815" alt="Screenshot 2023-06-07 at 11 54 05 AM" src="https://github.com/rangle/radius-monorepo-react/assets/23023263/8f2c5eff-a9ed-4ad4-bcda-45fbcd052518">
