### PR TITLE
feat: set defaults beased on TokenStudy Themes

### DIFF
--- a/apps/demo/app/root.tsx
+++ b/apps/demo/app/root.tsx
@@ -7,6 +7,7 @@ import {
   Scripts,
   ScrollRestoration,
 } from '@remix-run/react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 import styles from '@rangle/radius-foundations/styles.css';
 import { useMutationObserver } from './utils/demo.utils';
 
@@ -32,8 +33,22 @@ export function links() {
   ];
 }
 
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
 export default function App() {
   useMutationObserver();
+  const mainWrapper = useRef<HTMLDivElement>(null);
+  useIsomorphicLayoutEffect(() => {
+    if (mainWrapper.current) {
+      const defaultLayers = getComputedStyle(mainWrapper.current)
+        .getPropertyValue('--defaultLayers')
+        .split(',')
+        .map((s) => s.trim());
+      mainWrapper.current.classList.add(...defaultLayers);
+    }
+  }, []);
+
   return (
     <html lang="en">
       <head>
@@ -41,7 +56,7 @@ export default function App() {
         <Links />
       </head>
       <body>
-        <div className="saddles light-mode" data-radius-watch>
+        <div data-radius-watch ref={mainWrapper}>
           <Outlet />
         </div>
         <ScrollRestoration />

--- a/apps/demo/app/root.tsx
+++ b/apps/demo/app/root.tsx
@@ -9,6 +9,7 @@ import {
 } from '@remix-run/react';
 import { useEffect, useLayoutEffect, useRef } from 'react';
 import styles from '@rangle/radius-foundations/styles.css';
+import { defaultClassNames } from '@rangle/radius-foundations/generated/default-class-names.constants';
 import { useMutationObserver } from './utils/demo.utils';
 
 export const meta: MetaFunction = () => ({
@@ -38,16 +39,6 @@ const useIsomorphicLayoutEffect =
 
 export default function App() {
   useMutationObserver();
-  const mainWrapper = useRef<HTMLDivElement>(null);
-  useIsomorphicLayoutEffect(() => {
-    if (mainWrapper.current) {
-      const defaultLayers = getComputedStyle(mainWrapper.current)
-        .getPropertyValue('--defaultLayers')
-        .split(',')
-        .map((s) => s.trim());
-      mainWrapper.current.classList.add(...defaultLayers);
-    }
-  }, []);
 
   return (
     <html lang="en">
@@ -56,7 +47,7 @@ export default function App() {
         <Links />
       </head>
       <body>
-        <div data-radius-watch ref={mainWrapper}>
+        <div className={defaultClassNames.join(' ')} data-radius-watch>
           <Outlet />
         </div>
         <ScrollRestoration />

--- a/apps/demo/app/routes/index.tsx
+++ b/apps/demo/app/routes/index.tsx
@@ -16,8 +16,9 @@ import {
   Youtube,
   LightMode,
   DarkMode,
-} from '../../../../library/foundations/generated/icons';
-import { radiusTokens } from '../../../../library/foundations/generated/design-tokens.constants';
+} from '@rangle/radius-foundations/generated/icons';
+import { radiusTokens } from '@rangle/radius-foundations/generated/design-tokens.constants';
+import { imageBasePath } from '@rangle/radius-foundations/generated/default-class-names.constants';
 import {
   RadiusAutoLayout,
   RadiusButton,
@@ -183,7 +184,7 @@ export default function Index() {
                 as="img"
                 width="fill-parent"
                 height="fill-parent"
-                src="/brand/saddles/assets/semantic.image.hero.headerImage.webp"
+                src={`/${imageBasePath}/assets/semantic.image.hero.headerImage.webp`}
                 alt="Image Description"
                 className={css`
                   object-fit: cover;
@@ -197,7 +198,7 @@ export default function Index() {
             data-radius-target-attribute="src"
             data-radius-replace-value="/{--brandOrEvent}/{--brand}/assets/semantic.image.hero.headerImage.webp"
             className={`demo-hero ${css`
-              background: url(/brand/saddles/assets/semantic.image.hero.backgroundImage.webp);
+              background: url(/${imageBasePath}/assets/semantic.image.hero.backgroundImage.webp);
             `}`}
           />
         </span>
@@ -278,7 +279,7 @@ export default function Index() {
               {
                 alt: 'Descriptive text',
                 body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna',
-                src: '/brand/saddles/assets/semantic.image.smallImageTextItem.image01.webp',
+                src: `/${imageBasePath}/assets/semantic.image.smallImageTextItem.image01.webp`,
                 // @ts-expect-error needed for brand-switching demo
                 ['data-radius-watch-token-changes']: true,
                 ['data-radius-replace-value']:
@@ -287,7 +288,7 @@ export default function Index() {
               {
                 alt: 'Descriptive text',
                 body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna',
-                src: '/brand/saddles/assets/semantic.image.smallImageTextItem.image02.webp',
+                src: `/${imageBasePath}/assets/semantic.image.smallImageTextItem.image02.webp`,
                 // @ts-expect-error needed for brand-switching demo
                 ['data-radius-watch-token-changes']: true,
                 ['data-radius-replace-value']:
@@ -296,7 +297,7 @@ export default function Index() {
               {
                 alt: 'Descriptive text',
                 body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna',
-                src: '/brand/saddles/assets/semantic.image.smallImageTextItem.image03.webp',
+                src: `/${imageBasePath}/assets/semantic.image.smallImageTextItem.image03.webp`,
                 // @ts-expect-error needed for brand-switching demo
                 ['data-radius-watch-token-changes']: true,
                 ['data-radius-replace-value']:
@@ -305,7 +306,7 @@ export default function Index() {
               {
                 alt: 'Descriptive text',
                 body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna',
-                src: '/brand/saddles/assets/semantic.image.smallImageTextItem.image04.webp',
+                src: `/${imageBasePath}/assets/semantic.image.smallImageTextItem.image04.webp`,
                 // @ts-expect-error needed for brand-switching demo
                 ['data-radius-watch-token-changes']: true,
                 ['data-radius-replace-value']:
@@ -329,7 +330,7 @@ export default function Index() {
               data-radius-watch-token-changes
               data-radius-target-selector="img"
               data-radius-target-attribute="src"
-              data-radius-replace-value="/{--brandOrEvent}/{--brand}/assets/secondary-logo-{--mode}.svg"
+              data-radius-replace-value="/brand/{--brand}/assets/secondary-logo-{--mode}.svg"
             >
               <img
                 alt="Saddles logo"

--- a/apps/demo/app/utils/demo.utils.ts
+++ b/apps/demo/app/utils/demo.utils.ts
@@ -105,10 +105,7 @@ export const useMutationObserver = () => {
 
           const newValue = replaceValue.replace(
             /\{(--[\w]*)\}/g,
-            (_match, token) => {
-              console.log('>>>>', token);
-              return computedValues[`{${token}}`] || '';
-            }
+            (_match, token) => computedValues[`{${token}}`] || ''
           );
 
           console.log('references:', references);

--- a/apps/demo/remix.config.js
+++ b/apps/demo/remix.config.js
@@ -8,4 +8,5 @@ module.exports = {
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
   watchPaths: ['../../library'],
+  serverDependenciesToBundle: [/.*@rangle\/radius-.+/],
 };

--- a/library/foundations/generated/token-layers-0.8.2.json
+++ b/library/foundations/generated/token-layers-0.8.2.json
@@ -2,6 +2,7 @@
   "layers": [
     {
       "name": "core",
+      "isDefault": true,
       "isStatic": true,
       "variables": [
         {
@@ -7966,6 +7967,7 @@
     },
     {
       "name": "brand--photostop",
+      "isDefault": false,
       "isStatic": false,
       "variables": [
         {
@@ -12255,6 +12257,7 @@
     },
     {
       "name": "brand--saddles",
+      "isDefault": true,
       "isStatic": false,
       "variables": [
         {
@@ -16543,6 +16546,7 @@
     },
     {
       "name": "halloweenevent--saddles",
+      "isDefault": false,
       "isStatic": false,
       "variables": [
         {
@@ -16853,6 +16857,7 @@
     },
     {
       "name": "mode--light",
+      "isDefault": true,
       "isStatic": false,
       "variables": [
         {
@@ -17147,6 +17152,7 @@
     },
     {
       "name": "mode--dark",
+      "isDefault": false,
       "isStatic": false,
       "variables": [
         {
@@ -17441,6 +17447,7 @@
     },
     {
       "name": "breakpoint--desktop",
+      "isDefault": true,
       "isStatic": false,
       "variables": [
         {
@@ -18614,6 +18621,7 @@
     },
     {
       "name": "breakpoint--tablet",
+      "isDefault": false,
       "isStatic": false,
       "variables": [
         {
@@ -19788,6 +19796,7 @@
     },
     {
       "name": "breakpoint--mobile",
+      "isDefault": false,
       "isStatic": false,
       "variables": [
         {
@@ -20961,6 +20970,7 @@
     },
     {
       "name": "components--components",
+      "isDefault": true,
       "isStatic": true,
       "variables": [
         {

--- a/library/foundations/package.json
+++ b/library/foundations/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "test": "jest",
     "tokens:ci": "RADIUS_LAYERS_SUFFIX=-${npm_package_version} yarn tokens:validate",
-    "tokens:update": "export RADIUS_LAYERS_SUFFIX=-${npm_package_version} && yarn tokens:validate && yarn tokens:parse && yarn tokens:generate && yarn tokens:docs && yarn tokens:constants && yarn tokens:types",
+    "tokens:update": "export RADIUS_LAYERS_SUFFIX=-${npm_package_version} && yarn tokens:validate && yarn tokens:parse && yarn tokens:generate && yarn tokens:docs && yarn tokens:default-class-names && yarn tokens:constants && yarn tokens:types",
     "tokens:parse": "mkdir -p generated && cat ./tokens.json | ts-node scripts/to-layers.ts > generated/token-layers${RADIUS_LAYERS_SUFFIX}.json",
     "tokens:validate": "cat ./tokens.json | ts-node scripts/validate-layers.ts generated/token-layers${RADIUS_LAYERS_SUFFIX}.json",
     "tokens:assets": "export RADIUS_LAYERS_SUFFIX=-${npm_package_version} && node --require ts-node/register scripts/save-assets.ts generated/token-layers${RADIUS_LAYERS_SUFFIX}.json",
@@ -23,6 +23,7 @@
     "tokens:docs": "cat generated/token-layers${RADIUS_LAYERS_SUFFIX}.json | ts-node scripts/generate-theme.ts storybook > generated/04-token-documentation.mdx && prettier --version && prettier --config ../../.prettierrc --parser mdx --write generated/04-token-documentation.mdx",
     "tokens:types": "cat generated/token-layers${RADIUS_LAYERS_SUFFIX}.json | ts-node scripts/generate-theme.ts types > generated/design-tokens.types.ts && prettier --config ../../.prettierrc --write generated/design-tokens.types.ts",
     "tokens:constants": "cat generated/token-layers${RADIUS_LAYERS_SUFFIX}.json | ts-node scripts/generate-theme.ts constants > generated/design-tokens.constants.ts && prettier --config ../../.prettierrc --write generated/design-tokens.constants.ts",
+    "tokens:default-class-names": "cat generated/token-layers${RADIUS_LAYERS_SUFFIX}.json | ts-node scripts/generate-theme.ts defaultClassNames > generated/default-class-names.constants.ts && prettier --config ../../.prettierrc --write generated/default-class-names.constants.ts",
     "build-icons": "rm -rf generated/icons && svgr --icon --typescript --filename-case kebab --out-dir generated/icons --svgo-config ./svgo.config.js src/assets/icons/svg",
     "build-brands": "rm -rf generated/brand && mkdir -p generated/brand && cp -Rf ../../radius/brands/* generated/brand",
     "build": "yarn build-brands && yarn tokens:update && yarn build-icons && yarn tokens:assets"

--- a/library/foundations/scripts/generate-theme.ts
+++ b/library/foundations/scripts/generate-theme.ts
@@ -11,6 +11,7 @@ import {
   renderCSSVariables,
   renderTokenTypes,
   renderTokenObjects,
+  renderDefaultThemeClassNames,
 } from './templates';
 
 type RenderFunction = (
@@ -69,6 +70,8 @@ const templates: RenderTemplateMap = {
   constants: renderTokenObjects,
   // render storybook theme
   storybook: renderStorybookStory,
+  // render default theme class names
+  defaultClassNames: renderDefaultThemeClassNames,
   // default template for the test runner
   runner: renderCSSVariables,
 };

--- a/library/foundations/scripts/lib/token-parser.types.ts
+++ b/library/foundations/scripts/lib/token-parser.types.ts
@@ -20,9 +20,18 @@ export type JSONStructure = {
   [key: string]: JSONLeaf | JSONCompositeLeaf | JSONStructure;
 };
 
+/** Theme structure (requires Pro) */
+export type Theme = {
+  id: string;
+  name: string;
+  $figmaStyleReferences: Record<string, unknown>;
+  selectedTokenSets: Record<string, 'enabled' | 'source'>;
+  group: string;
+};
+
 /** Root structure of the JSON file */
 export type TokenStructure = Record<string, JSONStructure> & {
-  $themes: unknown[];
+  $themes: Theme[];
   $metadata: {
     tokenSetOrder: string[];
   };
@@ -118,6 +127,7 @@ export type TokenLayer = {
   name: string;
   parameters: Record<string, string | undefined>;
   dependencies: string[];
+  isDefault?: boolean;
   isStatic: boolean;
 };
 

--- a/library/foundations/scripts/save-assets.ts
+++ b/library/foundations/scripts/save-assets.ts
@@ -33,11 +33,19 @@ const findAssetSizeAndDimensions = async (url: string) => {
   console.info('fetching', url);
   return axios
     .get(url, { responseType: 'arraybuffer' })
+    .catch((e) => {
+      console.warn(`Error downloading ${url}`);
+      throw e;
+    })
     .then((response) => {
       console.info('downloaded. converting to webp');
       return sharp(Buffer.from(response.data))
         .webp()
-        .toBuffer({ resolveWithObject: true });
+        .toBuffer({ resolveWithObject: true })
+        .catch((e) => {
+          console.warn(`Error parsing ${url}`);
+          throw e;
+        });
     })
     .then(({ data, info }) => {
       return { data, info };

--- a/library/foundations/scripts/templates/default-theme-classes.template.ts
+++ b/library/foundations/scripts/templates/default-theme-classes.template.ts
@@ -1,0 +1,30 @@
+/*
+   TEMPLATE FOR DEFAULT CSS THEME CLASS NAMES
+   Generates a TS files that contains the default theme classe names
+   to apply to the body
+*/
+import { PARAM_SECTION_NAME } from '../lib/token-parser';
+import { toKebabCase } from '../lib/token-parser.utils';
+import { TokenLayers, TokenLayer } from '../lib/token-parser.types';
+
+const getDefaultClassNames = (layers: TokenLayer[]) => {
+  return layers.flatMap(({ name, isDefault, parameters }) => {
+    console.warn(name);
+    if (
+      ['core', 'components--components'].includes(name) ||
+      name.startsWith('breakpoint-')
+    ) {
+      return [];
+    }
+    const sectionName = parameters[PARAM_SECTION_NAME] ?? name;
+    return isDefault && sectionName ? toKebabCase(sectionName) : [];
+  });
+};
+
+export const renderDefaultThemeClassNames = ({ layers }: TokenLayers) =>
+  Buffer.from(`
+/** Default class-names to be applied to the body when the page loads */
+export const defaultClassNames = [${getDefaultClassNames(layers)
+    .map((l) => `"${l}",`)
+    .join('')}];
+`);

--- a/library/foundations/scripts/templates/default-theme-classes.template.ts
+++ b/library/foundations/scripts/templates/default-theme-classes.template.ts
@@ -7,13 +7,27 @@ import { PARAM_SECTION_NAME } from '../lib/token-parser';
 import { toKebabCase } from '../lib/token-parser.utils';
 import { TokenLayers, TokenLayer } from '../lib/token-parser.types';
 
-const getDefaultClassNames = (layers: TokenLayer[]) => {
-  return layers.flatMap(({ name, isDefault, parameters }) => {
+const isSwitchable = ({
+  name,
+  isStatic,
+}: Pick<TokenLayer, 'name' | 'isStatic'>) =>
+  !isStatic && !name.startsWith('breakpoint-');
+
+const getDefaultAssetPaths = (defaultLayers: TokenLayer[]) => {
+  const segements = defaultLayers
+    .map(({ name }) => name.split('--'))
+    .filter(([_, value]) => value !== undefined);
+  const event = segements.find(([group]) => group.endsWith('event'));
+  if (event) {
+    return event.join('/');
+  }
+  return segements.find(([group]) => group === 'brand')?.join('/');
+};
+
+const getDefaultClassNames = (defaultLayers: TokenLayer[]) => {
+  return defaultLayers.flatMap(({ name, isStatic, isDefault, parameters }) => {
     console.warn(name);
-    if (
-      ['core', 'components--components'].includes(name) ||
-      name.startsWith('breakpoint-')
-    ) {
+    if (!isSwitchable({ name, isStatic })) {
       return [];
     }
     const sectionName = parameters[PARAM_SECTION_NAME] ?? name;
@@ -21,10 +35,15 @@ const getDefaultClassNames = (layers: TokenLayer[]) => {
   });
 };
 
-export const renderDefaultThemeClassNames = ({ layers }: TokenLayers) =>
-  Buffer.from(`
+export const renderDefaultThemeClassNames = ({ layers }: TokenLayers) => {
+  const defaultLayers = layers.filter((l) => l.isDefault && isSwitchable(l));
+  return Buffer.from(`
 /** Default class-names to be applied to the body when the page loads */
-export const defaultClassNames = [${getDefaultClassNames(layers)
+export const defaultClassNames = [${getDefaultClassNames(defaultLayers)
     .map((l) => `"${l}",`)
     .join('')}];
+
+/** Initial base Path for images */
+export const imageBasePath = "${getDefaultAssetPaths(defaultLayers)}";
 `);
+};

--- a/library/foundations/scripts/templates/index.ts
+++ b/library/foundations/scripts/templates/index.ts
@@ -2,3 +2,4 @@ export * from './css-variables.template';
 export * from './storybook.template';
 export * from './token-types.template';
 export * from './token-objects.template';
+export * from './default-theme-classes.template';


### PR DESCRIPTION
"Default" theme set by TokenStudio (in $themes) dictates which themes get treated as defaults when loading the page.

When adding `"HalloweenEvent/Saddles": "enabled",` to the `Default` theme the page loads like this:
<img width="1445" alt="Screenshot 2023-06-22 at 12 02 18 PM" src="https://github.com/rangle/radius-monorepo-react/assets/1680390/aead2719-5e9e-41bd-b4a8-9406902c3efe">


